### PR TITLE
Add structured ISOInspector execution documentation suite

### DIFF
--- a/DOCS/ISOInspector_Execution_Guide/01_Project_Scope.md
+++ b/DOCS/ISOInspector_Execution_Guide/01_Project_Scope.md
@@ -1,0 +1,46 @@
+# ISOInspector Project Scope
+
+## Objective Statement
+Design and deliver a cross-platform ISO Base Media File Format (ISO BMFF / MP4 / QuickTime) inspection system composed of reusable Swift packages and distribution targets. The solution must parse, validate, and visualize MP4 structures for files up to 20 GB with <200 ms UI latency and <100 MB memory usage on Apple platforms.
+
+## Deliverables
+| # | Deliverable | Type | Description | Completion Criteria |
+|---|-------------|------|-------------|---------------------|
+| 1 | ISOInspectorCore | SwiftPM library | Streaming ISO BMFF parser, validator, and metadata exporter. | All parser APIs documented; passes validation suites; emits structured events for UI/CLI. |
+| 2 | ISOInspectorUI | SwiftPM library | SwiftUI component library for tree, detail, and hex visualization. | Renders parser events in interactive views with filtering and search. |
+| 3 | ISOInspectorCLI | Executable | Command-line interface wrapping the core parser with reporting and export commands. | Supports file inspection, validation summary, JSON export, and error reporting. |
+| 4 | ISOInspectorApp | App bundle | macOS + iPadOS + iOS app integrating core and UI packages. | Ships with onboarding, file picker, session management, and workspace persistence. |
+| 5 | Documentation Suite | Markdown + DocC | Developer onboarding, API reference, and user guides. | Published with navigation index, setup instructions, and troubleshooting appendix. |
+
+## Success Criteria
+- Stream-parse MP4/QuickTime files up to 20 GB.
+- Maintain steady-state memory usage below 100 MB during parsing sessions.
+- UI event propagation latency below 200 ms from parser emission to rendered view update.
+- 100% automated test coverage for parser primitives and validation rules.
+- CI pipeline executing build, test, lint, and documentation verification on every merge.
+
+## Constraints
+- Language: Swift 5.9+.
+- Frameworks: Foundation, Swift Concurrency, SwiftUI, Combine.
+- Platforms: macOS 13+, iOS 16+, iPadOS 16+.
+- No third-party runtime dependencies. Use only Apple SDKs and standard libraries.
+- Parser must support both little-endian and big-endian MP4 box payloads per ISO/IEC 14496.
+
+## Assumptions
+- Input files follow ISO BMFF container semantics; malformed boxes must be reported, not silently ignored.
+- Build tooling uses Swift Package Manager and Xcode 15+.
+- CI/CD environment provides macOS runners with Xcode preinstalled.
+
+## External Dependencies
+| Dependency | Purpose | Interaction Mode |
+|------------|---------|------------------|
+| ISO/IEC 14496-12 specification | Defines MP4 box structures and validation rules. | Consult for parser schema and validation invariants. |
+| MP4RA Registered Box Types ([mp4ra.org](https://mp4ra.org/registered-types/boxes)) | Registry of extended atom types and vendor-specific codes. | Synchronize supported box catalog and metadata. |
+| Apple Developer Documentation (Swift, SwiftUI, Combine) | API references for implementation. | Reference for concurrency, UI components, and best practices. |
+
+## Risks & Mitigations
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Large file streaming performance | Parser stalls or memory spikes. | Use chunked file IO with `FileHandle` async sequences and bounded buffers. |
+| Vendor-specific atoms missing from registry | Validation gaps. | Fallback to generic box handler; log unknown types; schedule research tasks (see `05_Research_Gaps.md`). |
+| UI rendering complexity on low-memory devices | App crashes or stutters. | Employ diffable data sources, virtualization, and lazy loading. |

--- a/DOCS/ISOInspector_Execution_Guide/02_Product_Requirements.md
+++ b/DOCS/ISOInspector_Execution_Guide/02_Product_Requirements.md
@@ -1,0 +1,69 @@
+# ISOInspector Product Requirements
+
+## Feature Overview & Rationale
+ISOInspector enables engineers and media technologists to introspect ISO BMFF (MP4/QuickTime) files through automated parsing, validation, and visualization. The system improves debugging velocity, ensures compliance with ISO/IEC 14496-12, and exposes extended box metadata via the MP4RA registry. Delivering both CLI and GUI interfaces ensures compatibility with automated workflows and manual inspection sessions.
+
+## Functional Requirements
+| ID | Component | Requirement | Acceptance Criteria |
+|----|-----------|-------------|---------------------|
+| FR-CORE-001 | ISOInspectorCore | Parse MP4 files via streaming I/O without loading entire file into memory. | Parsing 20 GB test fixture completes with peak memory <100 MB; event stream delivered incrementally. |
+| FR-CORE-002 | ISOInspectorCore | Validate box structure, size fields, and hierarchical relationships according to ISO/IEC 14496-12. | Malformed fixtures produce error reports identifying offending box offsets and reasons. |
+| FR-CORE-003 | ISOInspectorCore | Catalog recognized atom types using MP4RA registry metadata. | Known box types include name, description, version, and flags; unknown types flagged for research. |
+| FR-CORE-004 | ISOInspectorCore | Export parse results as JSON and binary capture for reproducibility. | CLI/UI trigger exports; resulting files round-trip with re-import verification. |
+| FR-UI-001 | ISOInspectorUI | Display hierarchical tree of boxes with search, filter, and expand/collapse controls. | Tree view updates in <200 ms upon new event; filter reduces nodes accordingly. |
+| FR-UI-002 | ISOInspectorUI | Provide detail pane with field-level metadata, hex viewer, and validation status. | Selecting a box populates metadata and hex window with highlighted ranges. |
+| FR-UI-003 | ISOInspectorUI | Support session bookmarking and annotations stored per file. | Users can add notes per box; data persists between launches via CoreData/JSON. |
+| FR-CLI-001 | ISOInspectorCLI | Offer commands `inspect`, `validate`, `export-json`, `export-report`. | Commands documented via `--help`; exit codes 0 success, >0 failure. |
+| FR-CLI-002 | ISOInspectorCLI | Support batch mode for inspecting multiple files with aggregated summary. | Provide table summarizing file size, box count, error count; output saved to CSV. |
+| FR-APP-001 | ISOInspectorApp | Integrate document browser, recent files, and workspace persistence. | App relaunch shows last session, including open files and notes. |
+| FR-DOC-001 | Documentation Suite | Provide onboarding guide, API reference, and troubleshooting steps. | README, DocC catalog, and FAQ published with cross-links. |
+
+## Non-Functional Requirements
+| ID | Category | Requirement | Validation |
+|----|----------|-------------|-----------|
+| NFR-PERF-001 | Performance | UI updates within 200 ms of parser event receipt. | Instrumentation using signposts verifies latency on reference hardware. |
+| NFR-PERF-002 | Performance | CLI completes validation of 4 GB reference file in <45 seconds on M2 Mac mini. | Automated performance test with benchmark fixture. |
+| NFR-RELI-001 | Reliability | Parser handles truncated or corrupted input without crashing. | Fuzz tests and malformed fixture suite run in CI. |
+| NFR-USAB-001 | Usability | UI supports VoiceOver and Dynamic Type accessibility. | Audit with Accessibility Inspector; automated UI tests verify labels. |
+| NFR-SEC-001 | Security | No network access required; sandboxed file access only. | Static analysis ensures absence of network calls; App Sandbox entitlements configured. |
+| NFR-MAINT-001 | Maintainability | 90% unit test code coverage across core modules. | CI coverage report threshold enforced. |
+| NFR-DOC-001 | Documentation | Docs updated with every release. | CI check ensures versioned docs changed when public API changes detected. |
+
+## User Interaction Flows
+### Flow 1 — GUI Inspection Session
+1. User launches ISOInspectorApp.
+2. App presents onboarding or recent files list.
+3. User selects or imports MP4 file via file picker.
+4. ISOInspectorCore streams parse events to ISOInspectorUI.
+5. Tree view populates incrementally; status banner indicates progress.
+6. User selects a box to view metadata and hex payload.
+7. User adds annotations, bookmarks boxes, or exports JSON report.
+8. Session metadata persists automatically for next launch.
+
+### Flow 2 — CLI Batch Validation
+1. User runs `isoinspector validate --input /path/*.mp4 --report summary.csv`.
+2. CLI expands glob, sequentially parses each file using core library.
+3. Validation results aggregated; summary table printed and stored.
+4. Exit code reflects aggregate success/failure for CI integration.
+
+### Flow 3 — Developer Extends Box Metadata
+1. Developer consults MP4RA registry ([link](https://mp4ra.org/registered-types/boxes)) for new atom types.
+2. Developer updates box catalog definitions in core module.
+3. Unit tests verify parser recognizes new type and populates metadata.
+4. Documentation updated to list new box support.
+
+## Edge Cases & Failure Scenarios
+| Scenario | Expected Handling |
+|----------|------------------|
+| File truncated mid-box | Parser emits error event with byte offset; UI highlights offending node; CLI exits with code 2. |
+| Box size field smaller than header | Parser reports malformed size, skips to next sync boundary, continues with warning. |
+| Unknown extended type | Parser registers entry under "Unknown" with raw type code; TODO created in `05_Research_Gaps.md`. |
+| Encrypted payload boxes | Parser records presence but does not attempt decryption; UI indicates restricted payload. |
+| Multi-gigabyte `mdat` box | Streaming chunk reader bypasses loading entire payload; UI exposes summary instead of raw hex. |
+| Concurrent file analysis sessions | Core library supports multiple parser instances with isolated state; UI displays progress per session. |
+
+## Compliance & Accessibility
+- Conform to ISO/IEC 14496-12 structural definitions and validation invariants.
+- Provide localization-ready strings with base English resources.
+- Ensure CLI output uses ASCII-compatible formatting for CI logs.
+- Enable keyboard navigation for all interactive UI components.

--- a/DOCS/ISOInspector_Execution_Guide/03_Technical_Spec.md
+++ b/DOCS/ISOInspector_Execution_Guide/03_Technical_Spec.md
@@ -1,0 +1,105 @@
+# ISOInspector Technical Specification
+
+## Architecture Overview
+The system is organized into layered Swift packages with clear separation of concerns:
+- **ISOInspectorCore** — Handles file I/O, streaming parse pipeline, validation rules, and metadata catalog.
+- **ISOInspectorUI** — SwiftUI components consuming core events via Combine publishers; provides visualization and user interactions.
+- **ISOInspectorCLI** — Command-line executable leveraging core parsing APIs and shared reporting utilities.
+- **ISOInspectorApp** — SwiftUI lifecycle application bundling core and UI modules with platform integrations (document browser, persistence).
+
+Components communicate through typed event streams and shared domain models to keep concurrency boundaries explicit and testable.
+
+## Module Responsibilities
+| Module | Responsibilities | Key Types | External References |
+|--------|------------------|-----------|---------------------|
+| Core.IO | Chunked file reader using `FileHandle.AsyncBytes` with configurable buffer size. | `ChunkReader`, `FileSlice`, `ReadContext` | Foundation | 
+| Core.Parser | Decode MP4 atom headers, dispatch to box-specific decoders, and emit events. | `BoxHeader`, `BoxDecoder`, `ParseEvent`, `ParsePipeline` | ISO/IEC 14496-12 | 
+| Core.Validation | Validate structural rules, track context stack, report warnings/errors. | `ValidationRule`, `ValidationIssue`, `ContextStack` | ISO/IEC 14496-12 | 
+| Core.Metadata | Maintain registry of known boxes referencing MP4RA data; provide descriptive metadata. | `BoxCatalog`, `BoxDescriptor` | MP4RA registry | 
+| Core.Export | Serialize parse tree and validation results to JSON and binary capture. | `JSONExporter`, `CaptureWriter` | Codable | 
+| UI.Tree | Render hierarchical tree with virtualization. | `BoxNode`, `BoxTreeView`, `BoxTreeStore` | SwiftUI | 
+| UI.Detail | Present metadata, hex viewer, annotations. | `BoxDetailView`, `HexView`, `AnnotationStore` | SwiftUI | 
+| UI.Session | Manage multi-file sessions, bookmarks, persistence via CoreData or JSON. | `SessionStore`, `Bookmark` | FileManager, CoreData | 
+| CLI.Commands | Command definitions for `inspect`, `validate`, `export`. | `InspectCommand`, `ValidateCommand` | ArgumentParser | 
+| CLI.Reporting | Format console output, CSV summary, exit codes. | `ReportFormatter`, `CSVWriter` | Foundation | 
+| App.Shell | SwiftUI App entry, window scenes, document importers. | `ISOInspectorApp`, `DocumentController` | SwiftUI, UniformTypeIdentifiers |
+
+## Data Flow
+1. **File ingestion** — CLI/UI passes file URLs to `ChunkReader` which reads sequential slices (default 1 MB) asynchronously.
+2. **Parsing pipeline** — `ParsePipeline` receives `FileSlice`, decodes headers (`BoxHeader`), consults `BoxCatalog` for known types, and constructs `ParseEvent` objects.
+3. **Validation** — Each `ParseEvent` passes through `ValidationRule` chain verifying structure (size fields, version compatibility, container nesting). Issues appended to event metadata.
+4. **Distribution** — Events published via `AsyncStream`/Combine publishers to subscribers (UI tree store, CLI reporter, exporters).
+5. **Persistence/Export** — UI or CLI triggers exporters that consume stored tree snapshots to produce JSON or binary capture.
+
+## Event Model
+```swift
+struct ParseEvent: Sendable, Codable {
+    let fileID: UUID
+    let boxPath: [BoxIdentifier]
+    let header: BoxHeader
+    let payloadOffset: UInt64
+    let payloadLength: UInt64
+    let metadata: BoxDescriptor?
+    let validationIssues: [ValidationIssue]
+    let timestamp: Date
+}
+```
+- `BoxIdentifier` includes four-character code, index among siblings, and optional extended type.
+- Events must be emitted in document order; consumers rely on monotonic offsets.
+
+## Parsing Algorithms
+1. Read 8-byte base header (size + type).
+2. If size == 1, read 8-byte large size; adjust payload length accordingly.
+3. If type == `uuid`, read 16-byte extended type GUID.
+4. Validate size ≥ header length; if not, emit error and attempt to resynchronize by skipping to next 4-byte boundary.
+5. For container boxes, recursively parse children while total bytes consumed < declared size.
+6. Use streaming recursion via explicit stack to avoid deep call stacks.
+7. `mdat` payload handled via skip; store metadata but do not buffer entire payload.
+
+## Validation Rules
+| Rule ID | Description | Severity | Enforcement |
+|---------|-------------|----------|-------------|
+| VR-001 | Box size must be ≥ header length. | Error | Immediate event flagged; skip payload. |
+| VR-002 | Container boxes must close exactly at declared size. | Error | Compare consumed bytes; emit error if mismatch. |
+| VR-003 | Version/flags must match MP4RA metadata when specified. | Warning | Compare metadata table; report mismatch. |
+| VR-004 | `ftyp` must appear before any media box. | Error | Track first non-`ftyp` encountered; emit error if missing. |
+| VR-005 | `moov` must precede `mdat` unless flagged streaming. | Warning | Evaluate order; attach suggestion. |
+| VR-006 | Unknown box types recorded for follow-up research. | Info | Append to research log with type code. |
+
+## Concurrency Model
+- Parsing executes on dedicated background task using Swift concurrency (`Task`, `AsyncStream`).
+- UI subscribes via `@StateObject` stores bridging Combine to SwiftUI.
+- CLI uses async/await to consume event streams sequentially.
+- Shared mutable state avoided; use actors for `BoxCatalog` updates and session persistence.
+
+## Error Handling Strategy
+- Distinguish between recoverable validation issues and fatal I/O errors.
+- Provide `ParseError` enumerations with localized descriptions for UI/CLI.
+- Ensure CLI exit codes map: `0` success, `1` validation warnings only, `2` validation errors, `3` fatal runtime error.
+
+## Testing & Verification
+| Test Type | Coverage | Tooling |
+|-----------|----------|---------|
+| Unit Tests | Parser primitives, validation rules, metadata mapping. | XCTest, JSON fixtures. |
+| Integration Tests | End-to-end parse of sample MP4 files, CLI command invocations. | XCTest + `swift test --enable-code-coverage`. |
+| Performance Tests | Measure parsing throughput and memory profile on large files. | XCTest Metrics, Instruments automation. |
+| Fuzzing | Randomized box sequences to ensure robustness. | SwiftFuzzer integration. |
+| UI Snapshot Tests | Validate SwiftUI views render expected layout. | SwiftSnapshotTesting. |
+| Accessibility Tests | VoiceOver labels, Dynamic Type scaling. | XCTest + Accessibility Inspector automation. |
+
+## Instrumentation & Telemetry
+- Add signposts (`os_signpost`) around parse stages to measure latency in Instruments.
+- Provide debug logging toggled via environment variables (`ISOINSPECTOR_LOG_LEVEL`).
+- CLI `--verbose` flag increases logging detail.
+
+## Packaging & Distribution
+- All modules defined in a single SwiftPM workspace with multiple targets.
+- App target configured via Xcode project referencing SwiftPM packages.
+- CI builds universal binaries for Apple silicon and Intel (where supported).
+- Release artifacts include CLI binary, SwiftPM packages, and notarized app bundle.
+
+## Documentation Strategy
+- Use DocC catalogs for API docs (`ISOInspector.docc`).
+- Markdown guides stored under `Docs/Guides` with version tagging.
+- Generate CLI man pages via `swift-argument-parser` autodoc.
+- Keep MP4 box catalog synced with MP4RA updates; include script to fetch registry JSON.

--- a/DOCS/ISOInspector_Execution_Guide/04_TODO_Workplan.md
+++ b/DOCS/ISOInspector_Execution_Guide/04_TODO_Workplan.md
@@ -1,0 +1,68 @@
+# ISOInspector Execution Workplan
+
+The following plan decomposes delivery into dependency-aware phases. Each task includes priority, estimated effort (in ideal engineer days), required tools, dependencies, and acceptance criteria.
+
+## Phase A — Foundations & Infrastructure
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| A1 | Initialize SwiftPM workspace with core, UI, CLI targets and shared test utilities. | High | 1 | None | SwiftPM, Xcode | Repository builds successfully; targets link with placeholder implementations. |
+| A2 | Configure CI pipeline (GitHub Actions or similar) for build, test, lint. | High | 1.5 | A1 | GitHub Actions, swiftlint | CI runs on pull requests; failing tests block merge. |
+| A3 | Set up DocC catalog and documentation publishing workflow. | Medium | 1 | A1 | DocC, SwiftPM | `docc` build succeeds; docs published artifact accessible. |
+
+## Phase B — Core Parsing Engine
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| B1 | Implement chunked file reader with configurable buffer size and tests. | High | 1.5 | A1 | Swift, XCTest | Reader streams 1 MB chunks; tests cover EOF, seek, and error paths. |
+| B2 | Build box header decoder supporting 32-bit, 64-bit, and `uuid` boxes. | High | 2 | B1 | Swift, XCTest | Unit tests for standard and extended headers; handles malformed sizes gracefully. |
+| B3 | Implement streaming parse pipeline with event emission and context stack. | High | 3 | B2 | Swift Concurrency, XCTest | Parsing sample files emits ordered events with correct offsets. |
+| B4 | Integrate MP4RA metadata catalog and fallback for unknown boxes. | High | 2 | B3 | Swift, JSON parsing | Catalog loads from bundled JSON; unknown types logged for research. |
+| B5 | Implement validation rules VR-001 to VR-006 with test coverage. | High | 2 | B3 | XCTest | Malformed fixtures trigger expected validation outcomes. |
+| B6 | Add JSON and binary export modules with regression tests. | Medium | 1.5 | B3 | Swift Codable | Exported files re-import successfully; CLI smoke tests pass. |
+
+## Phase C — User Interface Package
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| C1 | Create Combine bridge and state stores for parse events. | High | 1.5 | B3 | Combine, SwiftUI | Store receives events and updates snapshot without race conditions. |
+| C2 | Implement tree view with virtualization, search, and filters. | High | 2.5 | C1 | SwiftUI | UI renders >10k nodes smoothly; search reduces nodes instantly. |
+| C3 | Build detail pane with metadata, validation list, and hex viewer. | High | 3 | C1 | SwiftUI | Selecting node shows metadata; hex viewer displays payload windows. |
+| C4 | Add annotation and bookmark management with persistence hooks. | Medium | 2 | C1 | CoreData/JSON | Notes persist across app relaunch; tests validate storage schema. |
+| C5 | Implement accessibility features (VoiceOver labels, keyboard navigation). | Medium | 1.5 | C2, C3 | Accessibility Inspector | Accessibility audit passes; UI tests confirm focus order. |
+
+## Phase D — CLI Interface
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| D1 | Scaffold CLI using `swift-argument-parser` with base command. | Medium | 1 | B3 | Swift ArgumentParser | `isoinspector --help` displays subcommands. |
+| D2 | Implement `inspect` and `validate` commands with streaming output. | High | 2 | D1 | Swift, XCTest | Commands process sample files; exit codes match specification. |
+| D3 | Add `export-json` and `export-report` commands with file output. | Medium | 1.5 | D2, B6 | Swift | Generated files validated via schema tests. |
+| D4 | Create batch mode processing with aggregated summary + CSV export. | Medium | 1.5 | D2 | Swift, CSV writer | CLI handles multiple files; CSV contains expected rows and metrics. |
+
+## Phase E — Application Shell
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| E1 | Build SwiftUI app shell with document browser and recent files list. | Medium | 2 | C1 | SwiftUI, UniformTypeIdentifiers | Users can open local files; recents persist. |
+| E2 | Integrate parser event pipeline with UI components in app context. | High | 2 | E1, C2, C3 | SwiftUI | Opening file updates tree and detail views in real time. |
+| E3 | Implement session persistence (open files, annotations, layout). | Medium | 2 | E2, C4 | CoreData/JSON | Relaunch restores previous workspace state. |
+| E4 | Prepare app distribution configuration (bundle ID, entitlements, notarization). | Medium | 1.5 | E2 | Xcode, Notarytool | App builds and notarizes successfully; entitlements validated. |
+
+## Phase F — Quality Assurance & Documentation
+| Task ID | Description | Priority | Effort (days) | Dependencies | Tools | Acceptance Criteria |
+|---------|-------------|----------|---------------|--------------|-------|---------------------|
+| F1 | Develop automated test fixtures, including malformed MP4 samples. | High | 2 | B2 | Python (fixture generation), Swift | Fixtures stored with metadata; tests cover each failure mode. |
+| F2 | Configure performance benchmarks for large files. | Medium | 1.5 | B3 | XCTest Metrics | Benchmark thresholds recorded; CI fails when regressions occur. |
+| F3 | Author developer onboarding guide and API reference. | Medium | 2 | A3, B6, C3 | DocC, Markdown | Guides published; includes setup, architecture, and extension instructions. |
+| F4 | Produce user manual covering CLI and App workflows. | Medium | 1.5 | D3, E2 | Markdown | Manual includes screenshots, command examples, troubleshooting. |
+| F5 | Finalize release checklist and go-live runbook. | Medium | 1 | E4, F2 | Markdown | Checklist covers QA sign-off, documentation updates, release packaging. |
+
+## Parallelization Notes
+- Phase A must complete before downstream phases begin.
+- Within Phase B, tasks B1–B3 and B4–B6 follow sequential order; B4 can start once B3 has event emission stubs.
+- Phase C tasks C2 and C3 can run in parallel after C1. C4 depends on annotation store definitions from C3.
+- Phase D tasks proceed sequentially due to CLI command dependencies.
+- Phase E tasks E2 and E3 depend on UI components from Phase C.
+- Documentation and QA tasks in Phase F can overlap once dependent features stabilize.
+
+## Progress Tracking Metrics
+- Burn-down of remaining ideal days per phase.
+- Automated test coverage percentage per module.
+- Performance benchmark results (latency, memory, throughput).
+- Count of unresolved research tasks from `05_Research_Gaps.md`.

--- a/DOCS/ISOInspector_Execution_Guide/05_Research_Gaps.md
+++ b/DOCS/ISOInspector_Execution_Guide/05_Research_Gaps.md
@@ -1,0 +1,19 @@
+# ISOInspector Research & Investigation Tasks
+
+This log enumerates knowledge gaps and research activities required to ensure comprehensive coverage. Assign these tasks to investigation agents prior to implementation if prerequisites are missing.
+
+## Open Research Tasks
+| Task ID | Topic | Objective | Priority | Effort (days) | Dependencies | Research Approach | Acceptance Criteria |
+|---------|-------|-----------|----------|---------------|--------------|-------------------|---------------------|
+| R1 | MP4RA Synchronization | Determine process to fetch and update MP4 registered box metadata automatically. | High | 1 | None | Review [MP4RA registry](https://mp4ra.org/registered-types/boxes), inspect available data formats (HTML, CSV, JSON), design scraper or API client. | Documented script plan specifying source URLs, parsing strategy, and update frequency. |
+| R2 | Fixture Acquisition | Identify representative MP4 samples covering standard, fragmented, and vendor-specific atoms. | High | 2 | None | Search open datasets (Apple sample media, DASH-IF) and internal archives; compile licensing notes. | Curated list of sample files with download links, sizes, and licensing status. |
+| R3 | Accessibility Guidelines | Validate VoiceOver and Dynamic Type best practices for complex SwiftUI trees. | Medium | 1.5 | None | Review Apple Accessibility Programming Guide; gather examples from existing open-source apps. | Checklist of UI compliance actions integrated into Phase C tasks. |
+| R4 | Large File Performance Benchmarks | Determine benchmarking methodology and tooling for 20 GB files on macOS CI. | Medium | 2 | B1 | Investigate file generation techniques (dd, custom generator), virtualization requirements, and instrumentation. | Benchmark protocol document describing test data creation, measurement steps, and resource constraints. |
+| R5 | Export Schema Standardization | Research industry-standard JSON schemas for MP4 inspection reports. | Medium | 1.5 | B6 | Survey existing tools (Bento4, ffprobe) for report formats; evaluate compatibility. | Proposal comparing schema options with recommendation and mapping to ISOInspector fields. |
+| R6 | Annotation Persistence Strategy | Evaluate CoreData vs. JSON for cross-platform annotation storage. | Low | 1 | C4 | Review storage requirements, conflict resolution needs, and iCloud sync options. | Decision record outlining chosen storage mechanism with rationale. |
+| R7 | CLI Distribution | Investigate best practices for distributing signed CLI binaries for macOS and Linux. | Low | 1.5 | D3 | Review notarization, Homebrew tap creation, and Linux package formats. | Distribution plan covering signing, packaging, and update strategy. |
+
+## Tracking & Reporting
+- Update this table as research completes or new gaps are discovered.
+- Reference associated implementation tasks by Task ID from `04_TODO_Workplan.md` to maintain traceability.
+- Archive research summaries in project documentation once finalized.

--- a/DOCS/ISOInspector_Execution_Guide/README.md
+++ b/DOCS/ISOInspector_Execution_Guide/README.md
@@ -1,0 +1,12 @@
+# ISOInspector Execution Guide
+
+This directory consolidates implementation-ready documentation for the ISOInspector project. The files are structured to guide autonomous agents through project objectives, requirements, architecture, and execution plans without additional clarification.
+
+## Contents
+- `01_Project_Scope.md` — Objective definition, deliverables, constraints, and dependencies.
+- `02_Product_Requirements.md` — Feature-level requirements, flows, and edge cases.
+- `03_Technical_Spec.md` — Detailed architecture, data contracts, and component responsibilities.
+- `04_TODO_Workplan.md` — Dependency-aware task breakdown with metadata for autonomous execution.
+- `05_Research_Gaps.md` — Outstanding unknowns and targeted investigation tasks.
+
+Each file adheres to the structure and quality rules defined in `DOCS/RULES/01_PRD.md`, ensuring consistent terminology, explicit acceptance criteria, and actionable guidance for LLM-based implementation.


### PR DESCRIPTION
## Summary
- add ISOInspector Execution Guide directory with implementation-ready scope, requirements, technical specification, workplan, and research backlog
- document deliverables, success criteria, architecture, dependency-aware tasks, and research actions aligned with MP4RA registry guidance

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_e_68e12e7ddb008321b30bc1178661b1bf