### PR TITLE
Add outside-in XP TDD workflow guide

### DIFF
--- a/DOCS/RULES/02_TDD_XP_Workflow.md
+++ b/DOCS/RULES/02_TDD_XP_Workflow.md
@@ -1,0 +1,69 @@
+# XP-Inspired TDD Workflow (Outside-In)
+
+## Mission Statement
+You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
+
+## Guiding Principles
+- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components only when driven by failing tests at the current level.
+- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build, tests, and deployment pipeline passing.
+- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are acceptable only as placeholders that immediately fail and motivate implementation.
+- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify design while keeping feedback loops tight.
+- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest iterations.
+
+## Phase Overview
+1. **Initialize the Delivery Skeleton**
+   - Create repository structure, build configuration, package metadata, and dependency management files.
+   - Add continuous integration workflow (e.g., GitHub Actions) that runs the build, static checks, and the test suite.
+   - Configure automated release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes), even if artifacts are placeholders.
+   - Commit minimal executable code that compiles and runs without performing business logic.
+
+2. **Author High-Level Acceptance Tests**
+   - Define end-to-end or service-level tests expressing the primary behavior from a user or system perspective.
+   - Initially, tests may interact with CLI, API endpoints, or service boundaries that return canned or mock responses.
+   - Acceptance tests should currently fail, documenting the desired capabilities before implementation.
+
+3. **Drive Implementation Outside-In**
+   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing deeper collaborators.
+   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to describe the required collaboration.
+   - Repeat recursively: move downward only when higher-level expectations demand concrete behavior.
+   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing tests.
+
+4. **Refinement and Refactoring Cycle**
+   - After each green build, refactor to remove duplication, clarify intent, and improve design.
+   - Maintain strict test coverage for all refactorings; no functionality changes without failing tests first.
+   - Continuously evolve test suites: upgrade placeholder assertions into meaningful expectations as features solidify.
+
+5. **Deployment and Release Readiness**
+   - Ensure CI pipelines produce deployable artifacts on every run.
+   - Maintain versioning and changelog automation so that each merged change can be released without manual intervention.
+   - Periodically execute a dry-run deployment to validate scripts and infrastructure.
+
+## Iteration Template
+1. Pick the highest-priority failing acceptance test.
+2. Write/adjust a lower-level test that exposes the missing behavior.
+3. Implement the simplest code to satisfy the new test.
+4. Run the entire test suite and CI-equivalent checks locally.
+5. Refactor while keeping tests green.
+6. Commit with descriptive message referencing the behavior enabled.
+7. Update release notes or documentation if external behavior changes.
+
+## Documentation Expectations
+- Maintain a living architecture README that mirrors the current system boundaries.
+- For each iteration, record:
+  - The acceptance test scenario addressed.
+  - Newly introduced components or collaborators.
+  - Refactorings performed and their rationale.
+- Keep developer onboarding instructions current with the evolving build and deployment process.
+
+## Communication and Collaboration Norms
+- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid asynchronous collaborators.
+- Use feature flags or configuration toggles when partially implementing features to keep the main branch deployable.
+- Prefer small, frequent commits and pull requests aligned with single acceptance scenarios.
+
+## Definition of Done
+- All relevant tests (acceptance, integration, unit) pass locally and in CI.
+- Build, package, and release automation completes successfully with current changes.
+- Documentation and release notes reflect the implemented behavior.
+- No outstanding TODOs or FIXMEs without linked follow-up issues.
+
+Adhere to this workflow rigorously to embody outside-in TDD within an Extreme Programming context.


### PR DESCRIPTION
## Summary
- add a workflow guide for running extreme programming with outside-in TDD
- document phase breakdown, iteration steps, and definition of done for agents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e13f84c890832187626eaced5c159a