### PR TITLE
Add CI workflow and safeguard test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Build and Test (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Swift
+        uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '5.9'
+
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: swift build
+        run: swift build --build-tests
+
+      - name: swift test
+        run: swift test

--- a/Tests/ISOInspectorKitTests/CIWorkflowConfigurationTests.swift
+++ b/Tests/ISOInspectorKitTests/CIWorkflowConfigurationTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+final class CIWorkflowConfigurationTests: XCTestCase {
+    private var repositoryRoot: URL {
+        var url = URL(fileURLWithPath: #filePath)
+        // Ascend to Tests/ISOInspectorKitTests
+        url.deleteLastPathComponent() // current file
+        url.deleteLastPathComponent() // ISOInspectorKitTests
+        url.deleteLastPathComponent() // Tests
+        return url
+    }
+
+    func testCIWorkflowFileExistsWithSwiftBuildAndTestSteps() throws {
+        let workflowURL = repositoryRoot
+            .appending(path: ".github")
+            .appending(path: "workflows")
+            .appending(path: "ci.yml")
+        let workflowData = try Data(contentsOf: workflowURL)
+        let workflowContents = String(decoding: workflowData, as: UTF8.self)
+
+        XCTAssertTrue(workflowContents.contains("swift build"), "Expected workflow to build the package")
+        XCTAssertTrue(workflowContents.contains("swift test"), "Expected workflow to run the test suite")
+        XCTAssertTrue(workflowContents.contains("pull_request"), "Workflow should trigger on pull requests")
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds and tests the Swift package on pushes and pull requests to main
- introduce a regression test that ensures the CI workflow runs swift build and swift test on pull_request events

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e18445a20883218bc76ddd614759c7