### PR TITLE
Pin CI workflow to ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test:
     name: Build and Test (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- pin the CI workflow to the ubuntu-22.04 runner to remain compatible with swift-actions/setup-swift

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e18de81874832188b2b767638799b3