### PR TITLE
Fix CI workflow test URL construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-and-test:
     name: Build and Test (Ubuntu)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/Tests/ISOInspectorKitTests/CIWorkflowConfigurationTests.swift
+++ b/Tests/ISOInspectorKitTests/CIWorkflowConfigurationTests.swift
@@ -12,9 +12,9 @@ final class CIWorkflowConfigurationTests: XCTestCase {
 
     func testCIWorkflowFileExistsWithSwiftBuildAndTestSteps() throws {
         let workflowURL = repositoryRoot
-            .appending(path: ".github")
-            .appending(path: "workflows")
-            .appending(path: "ci.yml")
+            .appendingPathComponent(".github", isDirectory: true)
+            .appendingPathComponent("workflows", isDirectory: true)
+            .appendingPathComponent("ci.yml", isDirectory: false)
         let workflowData = try Data(contentsOf: workflowURL)
         let workflowContents = String(decoding: workflowData, as: UTF8.self)
 


### PR DESCRIPTION
## Summary
- build the CI workflow URL in tests using appendingPathComponent to maintain Linux compatibility

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e18de81874832188b2b767638799b3