### PR TITLE
Add chunked file reader for ISOInspectorKit

### DIFF
--- a/DOCS/INPROGRESS/B1_2025-10-04_Summary.md
+++ b/DOCS/INPROGRESS/B1_2025-10-04_Summary.md
@@ -1,0 +1,14 @@
+# B1 Chunked File Reader — Progress Summary (2025-10-04)
+
+## Overview
+- Delivered the `RandomAccessReader` protocol and `ChunkedFileReader` implementation, fulfilling Execution Workplan task B1.
+- Reader supports configurable chunk sizes (default 1 MiB), chunk-aligned caching, and propagates underlying IO errors with context.
+- Added comprehensive XCTest coverage covering sequential reads, cross-chunk spans, arbitrary offset seeks, EOF partial reads, out-of-bounds validation, and injected IO failure scenarios.
+
+## Impact
+- Provides the buffered IO foundation required by subsequent parser tasks (B2+), ensuring large files can be processed without full-memory loads.
+- Establishes error taxonomy (`ChunkedFileReader.Error`) to guide upstream pipeline handling of IO edge cases.
+
+## Next Considerations
+- Extend endian helper utilities on top of `RandomAccessReader` for box header parsing (B2).
+- Explore AsyncSequence exposure for streaming scenarios once parser layers demand it.

--- a/DOCS/INPROGRESS/B1_Chunked_File_Reader.md
+++ b/DOCS/INPROGRESS/B1_Chunked_File_Reader.md
@@ -22,7 +22,13 @@ Build the foundational streaming file reader used by ISOInspectorKit so that lar
 - **Platform differences (macOS/iOS vs Linux)** → abstract file handles so Linux-based CI can exercise logic; provide conditional compilation where necessary.
 
 ## Immediate Next Steps
-1. Define `RandomAccessReader` protocol (if not already present) covering length, seek, and read semantics derived from PRD File IO requirements.
-2. Implement concrete reader backed by `FileHandle` (fallback from PRD) with chunked buffer reuse and bounds checking.
-3. Write XCTest cases for: sequential chunk reads, seeking backwards/forwards, EOF partial chunk, and injected read errors.
-4. Wire reader into package manifest/tests and update documentation/comments as needed.
+ - [x] Define `RandomAccessReader` protocol covering length and offset-based read semantics derived from PRD File IO requirements.
+ - [x] Implement concrete reader backed by `FileHandle` with chunked buffer reuse, caching, and bounds checking.
+ - [x] Write XCTest cases for sequential and spanning chunk reads, seeking, EOF partial chunk, and injected read errors.
+ - [x] Wire reader into package manifest/tests and document the API for future parser integration.
+
+## Completion Notes (2025-10-04)
+- Added `RandomAccessReader` protocol and `ChunkedFileReader` implementation with configurable chunk size defaulting to 1 MiB.
+- Reader caches chunk-aligned buffers, validates requested ranges, and surfaces IO errors with contextual error cases.
+- Test suite covers sequential reads, multi-chunk spans, seeks, EOF handling, out-of-bounds requests, and injected IO failures.
+- Work aligns with Execution Guide Task B1 acceptance criteria; ready to unblock downstream parser tasks (B2+).

--- a/Sources/ISOInspectorKit/IO/ChunkedFileReader.swift
+++ b/Sources/ISOInspectorKit/IO/ChunkedFileReader.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+/// Reader that performs buffered, chunk-aligned file IO to minimise allocation while
+/// supporting random access.
+public final class ChunkedFileReader: RandomAccessReader {
+    public static let defaultChunkSize = 1_048_576
+
+    public enum Error: Swift.Error {
+        case invalidOffset(Int64)
+        case invalidCount(Int)
+        case requestedRangeOutOfBounds
+        case ioError(underlying: Swift.Error)
+    }
+
+    let file: ChunkedFileReaderRandomAccessFile
+    public let length: Int64
+    let chunkSize: Int
+
+    private var cachedChunkOffset: Int64?
+    private var cachedChunkData: Data
+    private let closeHandler: (() -> Void)?
+
+    public convenience init(fileURL: URL, chunkSize: Int = ChunkedFileReader.defaultChunkSize) throws {
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
+        guard let fileSize = attributes[.size] as? NSNumber else {
+            try? handle.close()
+            throw Error.ioError(underlying: CocoaError(.fileReadUnknown))
+        }
+        self.init(
+            length: fileSize.int64Value,
+            chunkSize: chunkSize,
+            file: FileHandleAdapter(handle: handle),
+            closeHandler: { try? handle.close() }
+        )
+    }
+
+    init(length: Int64, chunkSize: Int, file: ChunkedFileReaderRandomAccessFile, closeHandler: (() -> Void)? = nil) {
+        precondition(chunkSize > 0, "Chunk size must be positive")
+        precondition(length >= 0, "Length must be non-negative")
+        self.length = length
+        self.chunkSize = chunkSize
+        self.file = file
+        self.closeHandler = closeHandler
+        self.cachedChunkData = Data()
+    }
+
+    deinit {
+        closeHandler?()
+    }
+
+    public func read(at offset: Int64, count: Int) throws -> Data {
+        guard offset >= 0 else { throw Error.invalidOffset(offset) }
+        guard count >= 0 else { throw Error.invalidCount(count) }
+        guard count > 0 else { return Data() }
+        guard offset < length else { throw Error.requestedRangeOutOfBounds }
+        let upperBound = offset + Int64(count)
+        guard upperBound <= length else { throw Error.requestedRangeOutOfBounds }
+
+        var remaining = count
+        var currentOffset = offset
+        var result = Data(capacity: count)
+
+        while remaining > 0 {
+            let chunkOffset = alignedOffset(for: currentOffset)
+            let chunk = try loadChunk(at: chunkOffset)
+            let startIndex = Int(currentOffset - chunkOffset)
+            let available = chunk.count - startIndex
+            guard available > 0 else {
+                throw Error.ioError(underlying: CocoaError(.fileReadUnknown))
+            }
+            let portion = min(available, remaining)
+            result.append(chunk[startIndex..<(startIndex + portion)])
+            remaining -= portion
+            currentOffset += Int64(portion)
+        }
+
+        return result
+    }
+
+    private func alignedOffset(for position: Int64) -> Int64 {
+        let chunk = Int64(chunkSize)
+        return (position / chunk) * chunk
+    }
+
+    private func loadChunk(at offset: Int64) throws -> Data {
+        if cachedChunkOffset == offset, !cachedChunkData.isEmpty {
+            return cachedChunkData
+        }
+
+        do {
+            try file.seek(toOffset: UInt64(offset))
+            var buffer = Data(repeating: 0, count: chunkSize)
+            let readCount = try buffer.withUnsafeMutableBytes { pointer -> Int in
+                try file.read(into: pointer, requestedCount: chunkSize)
+            }
+            cachedChunkOffset = offset
+            cachedChunkData = buffer.prefix(readCount)
+            return cachedChunkData
+        } catch {
+            throw Error.ioError(underlying: error)
+        }
+    }
+}
+
+protocol ChunkedFileReaderRandomAccessFile {
+    func seek(toOffset offset: UInt64) throws
+    func read(into buffer: UnsafeMutableRawBufferPointer, requestedCount: Int) throws -> Int
+}
+
+private final class FileHandleAdapter: ChunkedFileReaderRandomAccessFile {
+    let handle: FileHandle
+
+    init(handle: FileHandle) {
+        self.handle = handle
+    }
+
+    func seek(toOffset offset: UInt64) throws {
+        try handle.seek(toOffset: offset)
+    }
+
+    func read(into buffer: UnsafeMutableRawBufferPointer, requestedCount: Int) throws -> Int {
+        let data = try handle.read(upToCount: requestedCount) ?? Data()
+        if let baseAddress = buffer.baseAddress, !data.isEmpty {
+            data.copyBytes(to: baseAddress.assumingMemoryBound(to: UInt8.self), count: data.count)
+        }
+        return data.count
+    }
+}

--- a/Sources/ISOInspectorKit/IO/RandomAccessReader.swift
+++ b/Sources/ISOInspectorKit/IO/RandomAccessReader.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Protocol describing the minimal interface necessary for the ISOInspector parser to
+/// perform random-access reads from a binary data source.
+public protocol RandomAccessReader {
+    /// Total length of the readable data in bytes.
+    var length: Int64 { get }
+
+    /// Reads `count` bytes starting at `offset` and returns them as `Data`.
+    /// - Parameters:
+    ///   - offset: Absolute byte offset in the data source.
+    ///   - count: Number of bytes to read.
+    /// - Returns: A `Data` value containing the requested bytes.
+    /// - Throws: Reader-specific errors when the operation cannot be completed.
+    func read(at offset: Int64, count: Int) throws -> Data
+}

--- a/Tests/ISOInspectorKitTests/ChunkedFileReaderTests.swift
+++ b/Tests/ISOInspectorKitTests/ChunkedFileReaderTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class ChunkedFileReaderTests: XCTestCase {
+    private var temporaryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        temporaryURL = directory.appendingPathComponent("fixture.bin")
+    }
+
+    override func tearDownWithError() throws {
+        if let url = temporaryURL {
+            try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+        }
+        temporaryURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testSequentialChunkReadsRespectConfiguredChunkSize() throws {
+        let chunkSize = 256
+        let totalChunks = 5
+        let data = Data((0..<(chunkSize * totalChunks)).map { UInt8($0 % 251) })
+        try data.write(to: temporaryURL)
+
+        let reader = try ChunkedFileReader(fileURL: temporaryURL, chunkSize: chunkSize)
+
+        let first = try reader.read(at: 0, count: chunkSize)
+        XCTAssertEqual(first, data.subdata(in: 0..<chunkSize))
+
+        let second = try reader.read(at: Int64(chunkSize), count: chunkSize)
+        XCTAssertEqual(second, data.subdata(in: chunkSize..<(chunkSize * 2)))
+    }
+
+    func testReadAllowsSeekingToArbitraryOffsets() throws {
+        let payload = Data((0..<1024).map { UInt8(($0 * 3) % 255) })
+        try payload.write(to: temporaryURL)
+
+        let reader = try ChunkedFileReader(fileURL: temporaryURL, chunkSize: 128)
+
+        let slice = try reader.read(at: 73, count: 50)
+        XCTAssertEqual(slice, payload.subdata(in: 73..<123))
+    }
+
+    func testPartialChunkAtEndOfFile() throws {
+        let chunkSize = 512
+        let totalSize = (chunkSize * 2) + 123
+        let payload = Data((0..<totalSize).map { UInt8(($0 * 7) % 253) })
+        try payload.write(to: temporaryURL)
+
+        let reader = try ChunkedFileReader(fileURL: temporaryURL, chunkSize: chunkSize)
+
+        let tail = try reader.read(at: Int64(totalSize - 123), count: 123)
+        XCTAssertEqual(tail, payload.suffix(123))
+    }
+
+    func testReadSpanningMultipleChunksReturnsContiguousBytes() throws {
+        let chunkSize = 128
+        let payload = Data((0..<512).map { UInt8($0 % 211) })
+        try payload.write(to: temporaryURL)
+
+        let reader = try ChunkedFileReader(fileURL: temporaryURL, chunkSize: chunkSize)
+
+        let offset = 60
+        let count = 200
+        let slice = try reader.read(at: Int64(offset), count: count)
+
+        XCTAssertEqual(slice, payload.subdata(in: offset..<(offset + count)))
+    }
+
+    func testReadBeyondEndOfFileThrows() throws {
+        let bytes = Data((0..<400).map { UInt8($0 % 233) })
+        try bytes.write(to: temporaryURL)
+
+        let reader = try ChunkedFileReader(fileURL: temporaryURL, chunkSize: 128)
+
+        XCTAssertThrowsError(try reader.read(at: 390, count: 32)) { error in
+            guard case ChunkedFileReader.Error.requestedRangeOutOfBounds? = error as? ChunkedFileReader.Error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testUnderlyingReadErrorIsSurfaced() throws {
+        final class FailingFile: ChunkedFileReaderRandomAccessFile {
+            func seek(toOffset offset: UInt64) throws {}
+            func read(into buffer: UnsafeMutableRawBufferPointer, requestedCount: Int) throws -> Int {
+                throw TestError.failure
+            }
+        }
+
+        enum TestError: Error { case failure }
+
+        let reader = ChunkedFileReader(
+            length: 1024,
+            chunkSize: 128,
+            file: FailingFile()
+        )
+
+        XCTAssertThrowsError(try reader.read(at: 0, count: 16)) { error in
+            guard case let ChunkedFileReader.Error.ioError(underlying)? = error as? ChunkedFileReader.Error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertTrue(underlying is TestError)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a RandomAccessReader protocol and chunked file reader with configurable buffering and error handling
- cover chunked reader behavior with tests for sequential, spanning, EOF, bounds, and injected failure scenarios
- update in-progress documentation with completion notes and add a progress summary for task B1

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e1934f948c832181c2dd0784d2bb8e