### PR TITLE
Update CI workflow to latest Swift setup action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   build-and-test:
     name: Build and Test (Ubuntu)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Swift
-        uses: swift-actions/setup-swift@v1
+        uses: swift-actions/setup-swift@v2.3.0
         with:
           swift-version: '5.9'
 


### PR DESCRIPTION
## Summary
- use `ubuntu-latest` for the CI runner
- update `swift-actions/setup-swift` to version 2.3.0

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19d0b58588321b9ab57796338f927