### PR TITLE
Add ISO BMFF box header decoder and helper tests

### DIFF
--- a/DOCS/INPROGRESS/B2_Box_Header_Decoder_Summary.md
+++ b/DOCS/INPROGRESS/B2_Box_Header_Decoder_Summary.md
@@ -1,0 +1,13 @@
+# B2 Progress Summary — Box Header Decoder
+
+## Completed Outcomes
+- Added big-endian decoding helpers to `RandomAccessReader` for 32-bit, 64-bit, and FourCC values with error reporting on short reads.
+- Introduced `FourCharCode` value type and `BoxHeader` model representing header metadata including payload range and optional UUID.
+- Implemented `BoxHeaderDecoder.readHeader` to handle standard, largesize, `uuid`, and zero-sized boxes while validating parent/file bounds.
+- Expanded the XCTest suite with dedicated fixtures covering nominal and malformed headers plus helper behavior.
+
+## Testing Snapshot
+- `swift test`
+
+## Follow-Ups
+- B2+: Evaluate exposing async streaming interfaces once higher parser layers require progressive reads.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,6 +1,6 @@
 # Next Tasks
 
-- B2 — In progress: see `B2_Box_Header_Decoder.md` for scope and next steps.
-- B2+: Explore AsyncSequence exposure for streaming scenarios once parser layers demand it.
+- [x] B2 — Header decoder implemented per `B2_Box_Header_Decoder.md` scope.
+- [ ] B2+: Explore AsyncSequence exposure for streaming scenarios once parser layers demand it.
 
 Extracted from the archived B1 progress summary.

--- a/Sources/ISOInspectorKit/IO/RandomAccessReader.swift
+++ b/Sources/ISOInspectorKit/IO/RandomAccessReader.swift
@@ -14,3 +14,43 @@ public protocol RandomAccessReader {
     /// - Throws: Reader-specific errors when the operation cannot be completed.
     func read(at offset: Int64, count: Int) throws -> Data
 }
+
+/// Errors thrown by helper decoding routines built on top of `RandomAccessReader`.
+public enum RandomAccessReaderValueDecodingError: Swift.Error, Equatable {
+    case truncatedRead(expected: Int, actual: Int)
+    case invalidFourCharacterCode(Data)
+}
+
+public extension RandomAccessReader {
+    func readUInt32(at offset: Int64) throws -> UInt32 {
+        try readInteger(at: offset)
+    }
+
+    func readUInt64(at offset: Int64) throws -> UInt64 {
+        try readInteger(at: offset)
+    }
+
+    func readFourCC(at offset: Int64) throws -> FourCharCode {
+        let byteCount = 4
+        let data = try read(at: offset, count: byteCount)
+        guard data.count == byteCount else {
+            throw RandomAccessReaderValueDecodingError.truncatedRead(expected: byteCount, actual: data.count)
+        }
+        do {
+            return try FourCharCode(data: data)
+        } catch {
+            throw RandomAccessReaderValueDecodingError.invalidFourCharacterCode(data)
+        }
+    }
+
+    private func readInteger<T: FixedWidthInteger>(at offset: Int64) throws -> T {
+        let expected = MemoryLayout<T>.size
+        let data = try read(at: offset, count: expected)
+        guard data.count == expected else {
+            throw RandomAccessReaderValueDecodingError.truncatedRead(expected: expected, actual: data.count)
+        }
+        return data.reduce(T(0)) { partialResult, byte in
+            (partialResult << 8) | T(byte)
+        }
+    }
+}

--- a/Sources/ISOInspectorKit/ISO/BoxHeader.swift
+++ b/Sources/ISOInspectorKit/ISO/BoxHeader.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct BoxHeader: Equatable {
+    public let type: FourCharCode
+    public let totalSize: Int64
+    public let headerSize: Int64
+    public let payloadRange: Range<Int64>
+    public let range: Range<Int64>
+    public let uuid: UUID?
+
+    public var startOffset: Int64 { range.lowerBound }
+    public var endOffset: Int64 { range.upperBound }
+}

--- a/Sources/ISOInspectorKit/ISO/BoxHeaderDecoder.swift
+++ b/Sources/ISOInspectorKit/ISO/BoxHeaderDecoder.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+public enum BoxHeaderDecodingError: Swift.Error {
+    case offsetOutsideParent(offset: Int64, parentRange: Range<Int64>)
+    case offsetBeyondReader(length: Int64, offset: Int64)
+    case truncatedField(expected: Int, actual: Int)
+    case invalidFourCharacterCode(Data)
+    case zeroSizeWithoutParent
+    case sizeOutOfRange(UInt64)
+    case invalidSize(totalSize: Int64, headerSize: Int64)
+    case exceedsParent(expectedEnd: Int64, parentEnd: Int64)
+    case exceedsReader(expectedEnd: Int64, readerLength: Int64)
+    case readerError(underlying: Swift.Error)
+}
+
+public enum BoxHeaderDecoder {
+    public static func readHeader(
+        from reader: RandomAccessReader,
+        at offset: Int64,
+        inParentRange parentRange: Range<Int64>? = nil
+    ) throws -> BoxHeader {
+        let parent = parentRange ?? (Int64(0)..<reader.length)
+        guard parent.contains(offset) else {
+            throw BoxHeaderDecodingError.offsetOutsideParent(offset: offset, parentRange: parent)
+        }
+        guard offset < reader.length else {
+            throw BoxHeaderDecodingError.offsetBeyondReader(length: reader.length, offset: offset)
+        }
+
+        let sizeField: UInt32
+        do {
+            sizeField = try reader.readUInt32(at: offset)
+        } catch let error as RandomAccessReaderValueDecodingError {
+            switch error {
+            case let .truncatedRead(expected, actual):
+                throw BoxHeaderDecodingError.truncatedField(expected: expected, actual: actual)
+            case let .invalidFourCharacterCode(data):
+                throw BoxHeaderDecodingError.invalidFourCharacterCode(data)
+            }
+        } catch {
+            throw BoxHeaderDecodingError.readerError(underlying: error)
+        }
+
+        let type: FourCharCode
+        do {
+            type = try reader.readFourCC(at: offset + 4)
+        } catch let error as RandomAccessReaderValueDecodingError {
+            switch error {
+            case let .truncatedRead(expected, actual):
+                throw BoxHeaderDecodingError.truncatedField(expected: expected, actual: actual)
+            case let .invalidFourCharacterCode(data):
+                throw BoxHeaderDecodingError.invalidFourCharacterCode(data)
+            }
+        } catch {
+            throw BoxHeaderDecodingError.readerError(underlying: error)
+        }
+
+        var headerSize: Int64 = 8
+        var cursor = offset + headerSize
+        var totalSize: Int64
+
+        if sizeField == 1 {
+            let largeSize: UInt64
+            do {
+                largeSize = try reader.readUInt64(at: cursor)
+            } catch let error as RandomAccessReaderValueDecodingError {
+                switch error {
+                case let .truncatedRead(expected, actual):
+                    throw BoxHeaderDecodingError.truncatedField(expected: expected, actual: actual)
+                case let .invalidFourCharacterCode(data):
+                    throw BoxHeaderDecodingError.invalidFourCharacterCode(data)
+                }
+            } catch {
+                throw BoxHeaderDecodingError.readerError(underlying: error)
+            }
+            guard largeSize <= UInt64(Int64.max) else {
+                throw BoxHeaderDecodingError.sizeOutOfRange(largeSize)
+            }
+            headerSize += 8
+            cursor += 8
+            totalSize = Int64(largeSize)
+        } else {
+            totalSize = Int64(sizeField)
+        }
+
+        var uuid: UUID?
+        if type.rawValue == "uuid" {
+            let uuidBytes: Data
+            do {
+                uuidBytes = try reader.read(at: cursor, count: 16)
+            } catch {
+                throw BoxHeaderDecodingError.readerError(underlying: error)
+            }
+            guard uuidBytes.count == 16 else {
+                throw BoxHeaderDecodingError.truncatedField(expected: 16, actual: uuidBytes.count)
+            }
+            headerSize += 16
+            cursor += 16
+            uuid = uuidFrom(bytes: uuidBytes)
+        }
+
+        if sizeField == 0 {
+            guard let parentRange = parentRange else {
+                throw BoxHeaderDecodingError.zeroSizeWithoutParent
+            }
+            totalSize = parentRange.upperBound - offset
+        }
+
+        guard totalSize >= headerSize else {
+            throw BoxHeaderDecodingError.invalidSize(totalSize: totalSize, headerSize: headerSize)
+        }
+
+        let endOffset = offset + totalSize
+        guard endOffset <= parent.upperBound else {
+            throw BoxHeaderDecodingError.exceedsParent(expectedEnd: endOffset, parentEnd: parent.upperBound)
+        }
+        guard endOffset <= reader.length else {
+            throw BoxHeaderDecodingError.exceedsReader(expectedEnd: endOffset, readerLength: reader.length)
+        }
+
+        let payloadRange = cursor..<endOffset
+        return BoxHeader(
+            type: type,
+            totalSize: totalSize,
+            headerSize: headerSize,
+            payloadRange: payloadRange,
+            range: offset..<endOffset,
+            uuid: uuid
+        )
+    }
+
+    private static func uuidFrom(bytes: Data) -> UUID {
+        let array = Array(bytes)
+        return UUID(uuid: (
+            array[0], array[1], array[2], array[3],
+            array[4], array[5], array[6], array[7],
+            array[8], array[9], array[10], array[11],
+            array[12], array[13], array[14], array[15]
+        ))
+    }
+}

--- a/Sources/ISOInspectorKit/ISO/FourCharCode.swift
+++ b/Sources/ISOInspectorKit/ISO/FourCharCode.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public enum FourCharCodeError: Swift.Error, Equatable {
+    case invalidLength(Int)
+    case invalidASCII(Data)
+}
+
+public struct FourCharCode: Equatable, Hashable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init(_ value: String) throws {
+        guard value.utf8.count == 4 else {
+            throw FourCharCodeError.invalidLength(value.utf8.count)
+        }
+        self.rawValue = value
+    }
+
+    public init(data: Data) throws {
+        guard data.count == 4 else {
+            throw FourCharCodeError.invalidLength(data.count)
+        }
+        guard let string = String(data: data, encoding: .ascii) else {
+            throw FourCharCodeError.invalidASCII(data)
+        }
+        try self.init(string)
+    }
+
+    public var description: String { rawValue }
+}

--- a/Tests/ISOInspectorKitTests/BoxHeaderDecoderTests.swift
+++ b/Tests/ISOInspectorKitTests/BoxHeaderDecoderTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class BoxHeaderDecoderTests: XCTestCase {
+    func testStandardBoxHeaderDecoding() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x18]) // size 24
+        data.append(contentsOf: [0x66, 0x74, 0x79, 0x70]) // ftyp
+        data.append(contentsOf: Array(repeating: 0x00, count: 16))
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        let header = try BoxHeaderDecoder.readHeader(
+            from: reader,
+            at: 0,
+            inParentRange: 0..<Int64(data.count)
+        )
+
+        XCTAssertEqual(header.type.rawValue, "ftyp")
+        XCTAssertEqual(header.totalSize, 24)
+        XCTAssertEqual(header.headerSize, 8)
+        XCTAssertEqual(header.payloadRange, 8..<24)
+        XCTAssertNil(header.uuid)
+    }
+
+    func testLargeSizeHeaderDecoding() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        data.append(contentsOf: [0x6D, 0x6F, 0x6F, 0x76]) // moov
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40]) // size 64
+        data.append(contentsOf: Array(repeating: 0xFF, count: 64 - 16))
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        let header = try BoxHeaderDecoder.readHeader(
+            from: reader,
+            at: 0,
+            inParentRange: 0..<Int64(data.count)
+        )
+
+        XCTAssertEqual(header.type.rawValue, "moov")
+        XCTAssertEqual(header.totalSize, 64)
+        XCTAssertEqual(header.headerSize, 16)
+        XCTAssertEqual(header.payloadRange, 16..<64)
+    }
+
+    func testUUIDBoxHeaderDecoding() throws {
+        let uuidBytes: [UInt8] = [
+            0x11, 0x22, 0x33, 0x44,
+            0x55, 0x66, 0x77, 0x88,
+            0x99, 0xAA, 0xBB, 0xCC,
+            0xDD, 0xEE, 0xFF, 0x00
+        ]
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x28]) // size 40
+        data.append(contentsOf: [0x75, 0x75, 0x69, 0x64]) // uuid
+        data.append(contentsOf: uuidBytes)
+        data.append(contentsOf: Array(repeating: 0x00, count: 40 - 24))
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        let header = try BoxHeaderDecoder.readHeader(
+            from: reader,
+            at: 0,
+            inParentRange: 0..<Int64(data.count)
+        )
+
+        XCTAssertEqual(header.type.rawValue, "uuid")
+        XCTAssertEqual(header.headerSize, 24)
+        XCTAssertEqual(header.totalSize, 40)
+        XCTAssertEqual(header.payloadRange, 24..<40)
+        XCTAssertEqual(header.uuid, UUID(uuid: (
+            uuidBytes[0], uuidBytes[1], uuidBytes[2], uuidBytes[3],
+            uuidBytes[4], uuidBytes[5], uuidBytes[6], uuidBytes[7],
+            uuidBytes[8], uuidBytes[9], uuidBytes[10], uuidBytes[11],
+            uuidBytes[12], uuidBytes[13], uuidBytes[14], uuidBytes[15]
+        )))
+    }
+
+    func testZeroSizedBoxExpandsToParentRangeEnd() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x6D, 0x64, 0x61, 0x74]) // mdat
+        let reader = InMemoryRandomAccessReader(data: data + Data(repeating: 0xAA, count: 24))
+
+        let header = try BoxHeaderDecoder.readHeader(
+            from: reader,
+            at: 0,
+            inParentRange: 0..<Int64(32)
+        )
+
+        XCTAssertEqual(header.totalSize, 32)
+        XCTAssertEqual(header.headerSize, 8)
+        XCTAssertEqual(header.payloadRange, 8..<32)
+    }
+
+    func testZeroSizedBoxWithoutParentRangeThrows() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+        data.append(contentsOf: [0x6D, 0x64, 0x61, 0x74])
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        XCTAssertThrowsError(
+            try BoxHeaderDecoder.readHeader(from: reader, at: 0, inParentRange: nil)
+        ) { error in
+            guard case BoxHeaderDecodingError.zeroSizeWithoutParent = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testHeaderExtendingBeyondParentThrows() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x20]) // size 32
+        data.append(contentsOf: [0x6D, 0x64, 0x61, 0x74])
+        data.append(contentsOf: Array(repeating: 0x00, count: 32 - 8))
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        XCTAssertThrowsError(
+            try BoxHeaderDecoder.readHeader(from: reader, at: 0, inParentRange: 0..<Int64(16))
+        ) { error in
+            guard case let BoxHeaderDecodingError.exceedsParent(expectedEnd, parentEnd) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertEqual(expectedEnd, 32)
+            XCTAssertEqual(parentEnd, 16)
+        }
+    }
+
+    func testTruncatedHeaderThrows() throws {
+        var data = Data()
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x01])
+        data.append(contentsOf: [0x6D, 0x64, 0x61, 0x74])
+        data.append(contentsOf: [0x00, 0x00, 0x00]) // truncated largesize
+        let reader = InMemoryRandomAccessReader(data: data)
+
+        XCTAssertThrowsError(
+            try BoxHeaderDecoder.readHeader(from: reader, at: 0, inParentRange: 0..<Int64(64))
+        ) { error in
+            guard case let BoxHeaderDecodingError.truncatedField(expected, actual) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertEqual(expected, 8)
+            XCTAssertEqual(actual, 3)
+        }
+    }
+}

--- a/Tests/ISOInspectorKitTests/InMemoryRandomAccessReader.swift
+++ b/Tests/ISOInspectorKitTests/InMemoryRandomAccessReader.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import ISOInspectorKit
+
+struct InMemoryRandomAccessReader: RandomAccessReader {
+    enum Error: Swift.Error {
+        case requestedRangeOutOfBounds
+    }
+
+    let data: Data
+
+    var length: Int64 { Int64(data.count) }
+
+    func read(at offset: Int64, count: Int) throws -> Data {
+        guard offset >= 0, count >= 0 else {
+            throw Error.requestedRangeOutOfBounds
+        }
+        let lower = Int(offset)
+        guard lower >= 0, lower <= data.count else {
+            throw Error.requestedRangeOutOfBounds
+        }
+        let upper = min(data.count, lower + count)
+        return data.subdata(in: lower..<upper)
+    }
+}

--- a/Tests/ISOInspectorKitTests/RandomAccessReaderEndianHelpersTests.swift
+++ b/Tests/ISOInspectorKitTests/RandomAccessReaderEndianHelpersTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class RandomAccessReaderEndianHelpersTests: XCTestCase {
+    func testReadUInt32BigEndian() throws {
+        let bytes: [UInt8] = [0x12, 0x34, 0x56, 0x78]
+        let reader = InMemoryRandomAccessReader(data: Data(bytes))
+
+        let value = try reader.readUInt32(at: 0)
+
+        XCTAssertEqual(value, 0x12345678)
+    }
+
+    func testReadUInt64BigEndian() throws {
+        let bytes: [UInt8] = [
+            0x01, 0x23, 0x45, 0x67,
+            0x89, 0xAB, 0xCD, 0xEF
+        ]
+        let reader = InMemoryRandomAccessReader(data: Data(bytes))
+
+        let value = try reader.readUInt64(at: 0)
+
+        XCTAssertEqual(value, 0x0123456789ABCDEF)
+    }
+
+    func testReadFourCC() throws {
+        let bytes: [UInt8] = [0x66, 0x74, 0x79, 0x70] // "ftyp"
+        let reader = InMemoryRandomAccessReader(data: Data(bytes))
+
+        let fourCC = try reader.readFourCC(at: 0)
+
+        XCTAssertEqual(fourCC.rawValue, "ftyp")
+    }
+
+    func testReadUInt32TruncatedReadThrows() throws {
+        let reader = InMemoryRandomAccessReader(data: Data([0x00, 0x01, 0x02]))
+
+        XCTAssertThrowsError(try reader.readUInt32(at: 0)) { error in
+            guard case let RandomAccessReaderValueDecodingError.truncatedRead(expected, actual) = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertEqual(expected, 4)
+            XCTAssertEqual(actual, 3)
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,3 @@
+# TODO
+
+_No open puzzles._


### PR DESCRIPTION
## Summary
- extend `RandomAccessReader` with big-endian integer and FourCC helpers plus supporting `FourCharCode` model
- implement `BoxHeader` and `BoxHeaderDecoder` to validate ISO BMFF headers including largesize, uuid, and zero-sized boxes
- cover the new behavior with XCTest cases and update in-progress documentation and todo tracking

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e235b15d948321b31bc6c6e2f3dc6b