### PR TITLE
Improve command prompts with concrete doc links

### DIFF
--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -1,12 +1,21 @@
 # SYSTEM PROMPT: Archive Current Work-in-Progress
 
 ## 🧩 PURPOSE
-Archive the current contents of `DOCS/INPROGRESS` into a sequentially numbered folder under `DOCS/TASK_ARCHIVE`, while preserving workflow continuity by detecting and carrying forward “next task” references.
+Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE), while preserving workflow continuity by detecting and carrying forward “next task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
 
 ---
 
 ## 🎯 GOAL
-Safely move all active task files from `DOCS/INPROGRESS` into a new, properly numbered archive folder and automatically prepare a new `next_tasks.md` file if the current summary references upcoming tasks.
+Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder and automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references upcoming tasks.
+
+---
+
+## 🔗 REFERENCE MATERIALS
+- [Root TODO list (`todo.md`)](../../todo.md)
+- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
+- [Backlog detail (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [Archive index (`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`)](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md)
 
 ---
 
@@ -28,16 +37,16 @@ DOCS/
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Inspect Current Work Folder
-- Look inside `DOCS/INPROGRESS`.
-- Detect any file whose name **contains “Summary”** or is exactly **“next_task.md”**.
-- If found, open and read the content.
+- Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and `F1_Test_Fixtures.md`).
+- Detect any file whose name **contains “Summary”** (such as a `Summary_of_Work.md`) or is exactly **`next_tasks.md`**.
+- If found, open and read the content to capture context that must persist after archiving.
 
 ### Step 2. Extract Mentions of Upcoming Tasks
-- Search the text for mentions of **pending**, **next**, or **upcoming** tasks.
+- Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 - If found, temporarily store this information to recreate it later.
 
 ### Step 3. Determine the Next Archive Folder Name
-- Target base path: `DOCS/TASK_ARCHIVE/`.
+- Target base path: [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE).
 - Folder naming pattern:
   ```
   {NN}_{TASK_NAME}
@@ -45,25 +54,26 @@ DOCS/
   Example: `02_Setup_Swift_SPM`
 - Find the highest existing prefix `{NN}`, increment it by one to define the new folder name, e.g. `03_New_Task_Name`.
 
-### Step 4. Create Archive Folder (if missing)
-- If `DOCS/TASK_ARCHIVE` does not exist, create it.
+- If [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE) does not exist, create it.
 - Then create the new subfolder for the current task using the name from Step 3.
 
 ### Step 5. Move Files to Archive
-- Move **all files and subfolders** from `DOCS/INPROGRESS` to the new archive folder.
+- Move **all files and subfolders** from [`DOCS/INPROGRESS`](../INPROGRESS) to the new archive folder.
 - Preserve structure and file integrity.
+- Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if it requires a new entry for the archived task set.
 
 ### Step 6. Recreate `next_tasks.md` (if applicable)
 - If Step 2 found mentions of next tasks:
-  - Create a new file:  
+  - Create a new file:
     ```
     DOCS/INPROGRESS/next_tasks.md
     ```
-  - Write the extracted list or short summary of those next tasks into it.
+  - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items tracked in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 
 ### Step 7. Report Result
 - Output the **path of the new archive folder**.
 - Indicate whether a **new `next_tasks.md`** file was created.
+- Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [`todo.md`](../../todo.md).
 
 ---
 

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -1,33 +1,46 @@
 # SYSTEM PROMPT: Select the Next Task
 
 ## 🧩 PURPOSE
-Automatically determine and initialize the next task to work on, following the predefined project rules and available task notes.
+Automatically determine and initialize the next task to work on, following the predefined project rules and available task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the authoritative TODO sources.
 
 ---
 
 ## 🎯 GOAL
-Read and apply the selection rules from `DOCS/RULES`, analyze pending tasks listed in `DOCS/INPROGRESS/next_tasks.md`, and create a new task document containing its title and a lightweight PRD outline based on the main project documentation.
+Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md), analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
+
+---
+
+## 🔗 REFERENCE MATERIALS
+- [Root TODO list (`todo.md`)](../../todo.md)
+- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Master PRD (`DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`)](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [Detailed backlog (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
+- [Workflow rules (`DOCS/RULES/02_TDD_XP_Workflow.md`)](../RULES/02_TDD_XP_Workflow.md)
 
 ---
 
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Read Task Selection Rules
-- Open the folder `DOCS/RULES/`.
-- Find the Markdown document that defines how to choose the next task (e.g., prioritization, dependencies, urgency).
-- Parse and understand its logic or priority criteria.
+- Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and dependency logic.
+- Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
+- Parse and understand the criteria before evaluating candidates.
 
 ### Step 2. Inspect Pending Tasks
-- Check if `DOCS/INPROGRESS/next_tasks.md` exists.
-- If present, read the file and extract the listed upcoming tasks or ideas.
+- Check if [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) exists.
+- If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over `B2+` streaming interface item.
 
 ### Step 3. Apply Selection Rules
 - Use the criteria from Step 1 to determine which task should be selected next.
 - If multiple tasks qualify, choose the one with the highest priority according to the rules.
-- If no tasks are found in `next_tasks.md`, the system may refer to other `todo` or `tasks` files in the project for fallback options from the file `/DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md` `⁨⁩DOCS⁩/AI/ISOViewer⁩` folder from its section "## 5) Detailed TODO (execution-ready, без кода)" on the line 122.
+- If no tasks are found in `next_tasks.md`, consult the broader backlog sources:
+  - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) for the authoritative workplan.
+  - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5) Detailed TODO (execution-ready, без кода)" section.
+  - The root [`todo.md`](../../todo.md) for any repo-level quick wins.
 
 ### Step 4. Create a New Task Document
-- Use the folder `DOCS/INPROGRESS/` as the target location.
+- Use the folder [`DOCS/INPROGRESS`](../INPROGRESS) as the target location.
 - Create a new Markdown file with a name matching the chosen task, e.g.:
   ```
   DOCS/INPROGRESS/03_Implement_New_Feature.md
@@ -52,9 +65,11 @@ List of measurable completion conditions.
 Any key hints or dependencies to consider.
 
 ## 🧠 Source References
-- DOCS/PRD/main_prd.md
-- DOCS/GUIDES/*
-- DOCS/RULES/*
+- [`DOCS/AI/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [`DOCS/RULES/`](../RULES)
+- Any relevant archived context in [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)
 ```
 - Keep it short, structured, and clear.
 
@@ -66,7 +81,7 @@ Any key hints or dependencies to consider.
 
 ## ✅ EXPECTED OUTPUT
 - A new file created in `DOCS/INPROGRESS` with the next task name and a lightweight PRD.
-- The task is chosen according to the defined rules in `DOCS/RULES` and the notes in `next_tasks.md` and the todo in `/DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`.
+- The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`](../INPROGRESS/next_tasks.md) and the backlog sources linked above.
 - A short summary confirming the selected task and the applied rules.
 
 ---


### PR DESCRIPTION
## Summary
- link the archive workflow prompt to the concrete INPROGRESS, TASK_ARCHIVE, and backlog documentation
- expand the select-next-task prompt with direct references to the rules, TODO sources, and PRD materials

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e251b48de083218e8018a4119a8bc8