### PR TITLE
Update START command with cross-references

### DIFF
--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -1,35 +1,35 @@
 # SYSTEM PROMPT: Start a New Task
 
 ## 🧩 PURPOSE
-Begin active implementation of tasks defined in the `DOCS/INPROGRESS` folder, following all established development rules, methodologies, and documentation dependencies.
+Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established development rules, methodologies, and documentation dependencies.
 
 ---
 
 ## 🎯 GOAL
-Execute one or more tasks currently stored in `DOCS/INPROGRESS`, fully adhering to the engineering standards and methodologies defined in `DOCS/RULES` — particularly the **TDD (Test-Driven Development)** and **XP (Extreme Programming)** principles.  
-Additionally, follow the PDD (Puzzle-Driven Development) process defined in the `04_PDD` document.
+Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and **XP (Extreme Programming)** principles.
+Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md).
 
 ---
 
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Identify Active Tasks
-- Scan all Markdown files inside `DOCS/INPROGRESS/`.  
+- Scan all Markdown files inside [`DOCS/INPROGRESS/`](../INPROGRESS).
 - Each file corresponds to a pending task.  
 - Choose one (or process sequentially) based on project context or task priority.
 
 ### Step 2. Load Methodology Rules
-- Open the folder `DOCS/RULES/`.
+- Open the folder [`DOCS/RULES/`](../RULES).
 - Pay special attention to:
-  - **02_TDD_XP_Workflow.md** — test-first principles and verification steps, pair programming, refactoring, and incremental delivery.  
-  - **04_PDD.md** — workflow for Puzzle-Driven Development.  
+  - [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — test-first principles and verification steps, pair programming, refactoring, and incremental delivery.
+  - [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md) — workflow for Puzzle-Driven Development.
 - Keep these rules in mind during all implementation actions.
 
 ### Step 3. Gather Additional References
 - If needed, consult files in other subfolders under `DOCS/`:
-  - `DOCS/AI/ISOViewer/` – main product requirements.  
-  - `DOCS/AI/ISOInspector_Execution_Guide` – style guides or architecture notes.  
-  - `DOCS/MP4_Specs/` – interface or API specifications.  
+  - [`DOCS/AI/ISOViewer`](../AI/ISOViewer) – main product requirements (e.g., [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
+  - [`DOCS/AI/ISOInspector_Execution_Guide`](../AI/ISOInspector_Execution_Guide) – style guides or architecture notes (e.g., [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)).
+  - [`DOCS/MP4_Specs`](../MP4_Specs) – interface or API specifications.
 - Use them to clarify edge cases or functional expectations.
 
 ### Step 4. Implement According to TDD + XP + PDD
@@ -42,16 +42,16 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in the 
   - Refactor continuously.
   - Maintain test coverage.
 - Respect **PDD**, try to:
-  - Treat each file in `DOCS/INPROGRESS` as a “puzzle.”
+  - Treat each file in [`DOCS/INPROGRESS`](../INPROGRESS) as a “puzzle.”
   - Commit after each solved puzzle (atomic unit of work).
 
 ### Step 5. Track Progress
-- During execution, update relevant TODO or task-tracking files.  
-- When a puzzle or task is completed, **mark it as done** in the corresponding todo list in `DOCS/AI/ISOViewer/` and in any other status list.
+- During execution, update relevant TODO or task-tracking files.
+- When a puzzle or task is completed, **mark it as done** in the corresponding todo list in [`DOCS/AI/ISOViewer`](../AI/ISOViewer) (such as [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other status list.
 
 ### Step 6. Write Summary
 - After all current tasks are implemented:
-  - Create a new summary document inside `DOCS/INPROGRESS/`:
+  - Create a new summary document inside [`DOCS/INPROGRESS/`](../INPROGRESS):
     ```
     DOCS/INPROGRESS/Summary_of_Work.md
     ```
@@ -62,8 +62,8 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in the 
     - Any pending follow-up actions (if applicable).
 
 ### Step 7. Finalize
-- Ensure all unit tests pass.  
-- Ensure the documentation and task markers are consistent.  
+- Ensure all unit tests pass.
+- Ensure the documentation and task markers are consistent.
 - Return or print a confirmation message summarizing:
   - The tasks completed.  
   - The location of the summary file.
@@ -72,9 +72,9 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in the 
 
 ## ✅ EXPECTED OUTPUT
 
-- All designated tasks from `DOCS/INPROGRESS` have been implemented.  
-- Corresponding entries in `todo` files marked as completed.  
-- A new file `Summary_of_Work.md` created in `DOCS/INPROGRESS/` with concise details of what was done.  
+- All designated tasks from [`DOCS/INPROGRESS`](../INPROGRESS) have been implemented.
+- Corresponding entries in [`todo.md`](../../todo.md) and related files are marked as completed.
+- A new file [`Summary_of_Work.md`](../INPROGRESS/Summary_of_Work.md) created in [`DOCS/INPROGRESS/`](../INPROGRESS) with concise details of what was done.
 - No untracked changes remain.
 
 ---
@@ -115,8 +115,8 @@ DOCS/
 ---
 
 ## 🧾 NOTES
-- Never skip the analysis of `DOCS/RULES` — these define coding discipline.  
-- Each task file in `DOCS/INPROGRESS` is treated as an independent, verifiable unit.  
+- Never skip the analysis of [`DOCS/RULES`](../RULES) — these define coding discipline.
+- Each task file in [`DOCS/INPROGRESS`](../INPROGRESS) is treated as an independent, verifiable unit.
 - Maintain atomic commits, small iterations, and constant refactoring.  
 - Summaries and todo updates close the PDD loop.
 


### PR DESCRIPTION
## Summary
- replace plain folder references in the START command with links to the actual documentation files
- highlight specific TODO sources such as todo.md and Summary_of_Work.md for consistency with other command docs

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68e252d0e35083219a40fc4627d6c3e7