### PR TITLE
Add Markdown validation workflow for docs directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,21 @@ on:
       - main
 
 jobs:
+  markdown-validation:
+    name: Markdown Validation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint Markdown files
+        uses: DavidAnson/markdownlint-cli2-action@v13
+        with:
+          globs: |
+            DOCS/INPROGRESS/**/*.md
+            DOCS/COMMANDS/**/*.md
+            DOCS/RULES/**/*.md
+
   build-and-test:
     name: Build and Test (Ubuntu)
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary
- add a CI job that runs markdownlint on the DOCS/INPROGRESS, DOCS/COMMANDS, and DOCS/RULES directories

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2553db36c832196b1b73ef6bf0630