### PR TITLE
Fix markdownlint issues in docs

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,18 @@
+{
+  "default": true,
+  "MD013": {
+    "line_length": 120,
+    "heading_line_length": 120,
+    "code_blocks": false,
+    "tables": false,
+    "strict": false
+  },
+  "MD025": {
+    "level": 1
+  },
+  "MD040": true,
+  "MD022": true,
+  "MD032": true,
+  "MD031": true,
+  "MD047": true
+}

--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -11,6 +11,7 @@ Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a
 ---
 
 ## 🔗 REFERENCE MATERIALS
+
 - [Root TODO list (`todo.md`)](../../todo.md)
 - [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
 - [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
@@ -21,7 +22,7 @@ Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a
 
 ## 📁 DIRECTORY STRUCTURE
 
-```
+```text
 DOCS/
  ├── INPROGRESS/
  │    ├── ...
@@ -37,20 +38,25 @@ DOCS/
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Inspect Current Work Folder
+
 - Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and `F1_Test_Fixtures.md`).
 - Detect any file whose name **contains “Summary”** (such as a `Summary_of_Work.md`) or is exactly **`next_tasks.md`**.
 - If found, open and read the content to capture context that must persist after archiving.
 
 ### Step 2. Extract Mentions of Upcoming Tasks
+
 - Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 - If found, temporarily store this information to recreate it later.
 
 ### Step 3. Determine the Next Archive Folder Name
+
 - Target base path: [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE).
 - Folder naming pattern:
-  ```
+
+  ```text
   {NN}_{TASK_NAME}
   ```
+
   Example: `02_Setup_Swift_SPM`
 - Find the highest existing prefix `{NN}`, increment it by one to define the new folder name, e.g. `03_New_Task_Name`.
 
@@ -58,19 +64,25 @@ DOCS/
 - Then create the new subfolder for the current task using the name from Step 3.
 
 ### Step 5. Move Files to Archive
+
 - Move **all files and subfolders** from [`DOCS/INPROGRESS`](../INPROGRESS) to the new archive folder.
 - Preserve structure and file integrity.
 - Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if it requires a new entry for the archived task set.
 
 ### Step 6. Recreate `next_tasks.md` (if applicable)
+
 - If Step 2 found mentions of next tasks:
+
   - Create a new file:
-    ```
+
+    ```text
     DOCS/INPROGRESS/next_tasks.md
     ```
+
   - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items tracked in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 
 ### Step 7. Report Result
+
 - Output the **path of the new archive folder**.
 - Indicate whether a **new `next_tasks.md`** file was created.
 - Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [`todo.md`](../../todo.md).
@@ -89,7 +101,7 @@ DOCS/
 ## 🧠 EXAMPLE
 
 **Before:**
-```
+```text
 DOCS/
  ├── INPROGRESS/
  │    ├── README.md
@@ -100,7 +112,7 @@ DOCS/
 ```
 
 **After:**
-```
+```text
 DOCS/
  ├── INPROGRESS/
  │    └── next_tasks.md
@@ -113,6 +125,7 @@ DOCS/
 ---
 
 ## 🧾 NOTES
+
 - Always analyze the content before moving files.
 - Maintain numeric order continuity.
 - Never overwrite existing archive folders.
@@ -120,4 +133,4 @@ DOCS/
 
 ---
 
-# END OF SYSTEM PROMPT
+## END OF SYSTEM PROMPT

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -11,6 +11,7 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
 ---
 
 ## 🔗 REFERENCE MATERIALS
+
 - [Root TODO list (`todo.md`)](../../todo.md)
 - [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
 - [Master PRD (`DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`)](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
@@ -23,33 +24,41 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Read Task Selection Rules
+
 - Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and dependency logic.
 - Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
 - Parse and understand the criteria before evaluating candidates.
 
 ### Step 2. Inspect Pending Tasks
+
 - Check if [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) exists.
 - If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over `B2+` streaming interface item.
 
 ### Step 3. Apply Selection Rules
+
 - Use the criteria from Step 1 to determine which task should be selected next.
 - If multiple tasks qualify, choose the one with the highest priority according to the rules.
 - If no tasks are found in `next_tasks.md`, consult the broader backlog sources:
+
   - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) for the authoritative workplan.
   - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5) Detailed TODO (execution-ready, без кода)" section.
   - The root [`todo.md`](../../todo.md) for any repo-level quick wins.
 
 ### Step 4. Create a New Task Document
+
 - Use the folder [`DOCS/INPROGRESS`](../INPROGRESS) as the target location.
 - Create a new Markdown file with a name matching the chosen task, e.g.:
-  ```
+
+  ```text
   DOCS/INPROGRESS/03_Implement_New_Feature.md
   ```
+
 - Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and guides located in other DOCS subfolders.
 
 ### Step 5. PRD Content Template
 The created file should include the following structure:
-```
+
+```markdown
 # {TASK_TITLE}
 
 ## 🎯 Objective
@@ -74,12 +83,14 @@ Any key hints or dependencies to consider.
 - Keep it short, structured, and clear.
 
 ### Step 6. Report Result
+
 - Output the name of the chosen task.
 - Confirm that the new Markdown PRD file was successfully created in `DOCS/INPROGRESS`.
 
 ---
 
 ## ✅ EXPECTED OUTPUT
+
 - A new file created in `DOCS/INPROGRESS` with the next task name and a lightweight PRD.
 - The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`](../INPROGRESS/next_tasks.md) and the backlog sources linked above.
 - A short summary confirming the selected task and the applied rules.
@@ -89,7 +100,8 @@ Any key hints or dependencies to consider.
 ## 🧠 EXAMPLE
 
 **Before:**
-```
+
+```text
 DOCS/
  ├── RULES/
  │    └── task_selection_rules.md
@@ -100,7 +112,8 @@ DOCS/
 ```
 
 **After:**
-```
+
+```text
 DOCS/
  ├── RULES/
  │    └── task_selection_rules.md
@@ -121,4 +134,4 @@ DOCS/
 
 ---
 
-# END OF SYSTEM PROMPT
+## END OF SYSTEM PROMPT

--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -14,58 +14,79 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 ## ⚙️ EXECUTION STEPS
 
 ### Step 1. Identify Active Tasks
+
 - Scan all Markdown files inside [`DOCS/INPROGRESS/`](../INPROGRESS).
-- Each file corresponds to a pending task.  
+- Each file corresponds to a pending task.
 - Choose one (or process sequentially) based on project context or task priority.
 
 ### Step 2. Load Methodology Rules
+
 - Open the folder [`DOCS/RULES/`](../RULES).
 - Pay special attention to:
+
   - [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — test-first principles and verification steps, pair programming, refactoring, and incremental delivery.
   - [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md) — workflow for Puzzle-Driven Development.
+
 - Keep these rules in mind during all implementation actions.
 
 ### Step 3. Gather Additional References
+
 - If needed, consult files in other subfolders under `DOCS/`:
+
   - [`DOCS/AI/ISOViewer`](../AI/ISOViewer) – main product requirements (e.g., [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
   - [`DOCS/AI/ISOInspector_Execution_Guide`](../AI/ISOInspector_Execution_Guide) – style guides or architecture notes (e.g., [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)).
   - [`DOCS/MP4_Specs`](../MP4_Specs) – interface or API specifications.
+
 - Use them to clarify edge cases or functional expectations.
 
 ### Step 4. Implement According to TDD + XP + PDD
+
 - Follow **TDD cycle**:
+
   1. Write a failing test.
-  2. Implement the minimal code to make it pass.
-  3. Refactor and repeat.
+  1. Implement the minimal code to make it pass.
+  1. Refactor and repeat.
+
 - Apply **XP principles**:
+
   - Keep iterations small.
   - Refactor continuously.
   - Maintain test coverage.
+
 - Respect **PDD**, try to:
+
   - Treat each file in [`DOCS/INPROGRESS`](../INPROGRESS) as a “puzzle.”
   - Commit after each solved puzzle (atomic unit of work).
 
 ### Step 5. Track Progress
+
 - During execution, update relevant TODO or task-tracking files.
 - When a puzzle or task is completed, **mark it as done** in the corresponding todo list in [`DOCS/AI/ISOViewer`](../AI/ISOViewer) (such as [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other status list.
 
 ### Step 6. Write Summary
+
 - After all current tasks are implemented:
+
   - Create a new summary document inside [`DOCS/INPROGRESS/`](../INPROGRESS):
-    ```
+
+    ```text
     DOCS/INPROGRESS/Summary_of_Work.md
     ```
+
   - Include:
-    - Completed task names.  
-    - Short description of implementation results.  
-    - References to commits, tests, or updated specs.  
+
+    - Completed task names.
+    - Short description of implementation results.
+    - References to commits, tests, or updated specs.
     - Any pending follow-up actions (if applicable).
 
 ### Step 7. Finalize
+
 - Ensure all unit tests pass.
 - Ensure the documentation and task markers are consistent.
 - Return or print a confirmation message summarizing:
-  - The tasks completed.  
+
+  - The tasks completed.
   - The location of the summary file.
 
 ---
@@ -82,7 +103,8 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 ## 🧠 EXAMPLE
 
 **Before:**
-```
+
+```text
 DOCS/
  ├── INPROGRESS/
  │    ├── 03_Add_Logging.md
@@ -97,7 +119,8 @@ DOCS/
 ```
 
 **After:**
-```
+
+```text
 DOCS/
  ├── INPROGRESS/
  │    ├── Summary_of_Work.md
@@ -115,11 +138,12 @@ DOCS/
 ---
 
 ## 🧾 NOTES
+
 - Never skip the analysis of [`DOCS/RULES`](../RULES) — these define coding discipline.
 - Each task file in [`DOCS/INPROGRESS`](../INPROGRESS) is treated as an independent, verifiable unit.
-- Maintain atomic commits, small iterations, and constant refactoring.  
+- Maintain atomic commits, small iterations, and constant refactoring.
 - Summaries and todo updates close the PDD loop.
 
 ---
 
-# END OF SYSTEM PROMPT
+## END OF SYSTEM PROMPT

--- a/DOCS/RULES/01_PRD.md
+++ b/DOCS/RULES/01_PRD.md
@@ -1,38 +1,46 @@
+# PRD Authoring Rules
+
 System: You are an expert project analyst and specification architect, specialized in creating implementation-ready technical assignments (Tech Specs), actionable TODO breakdowns, and complete PRD (Product Requirements Documents) tailored for execution by LLM-based agents. Your output must be self-contained, unambiguous, and machine-readable, enabling LLM agents to execute the plan without human clarification.
 
 For each provided high-level goal or idea:
 
 1. Define the scope and intent.
-   • Restate the objective in precise, unambiguous terms.
-   • Identify the primary deliverables and success criteria.
-   • Explicitly note any constraints, assumptions, or external dependencies.
 
-2. Decompose into a structured, hierarchical TODO plan.
-   • Break the task into atomic, verifiable subtasks.
-   • Ensure each subtask has a clear input, process, and expected output.
-   • Group subtasks into logical phases or categories.
-   • Explicitly state dependencies and opportunities for parallel execution.
+   - Restate the objective in precise, unambiguous terms.
+   - Identify the primary deliverables and success criteria.
+   - Explicitly note any constraints, assumptions, or external dependencies.
 
-3. Enrich each subtask with execution metadata.
-   • Priority (High / Medium / Low).
-   • Effort estimate (time or complexity score).
-   • Required tools, frameworks, APIs, or datasets.
-   • Expected acceptance criteria and verification methods.
+1. Decompose into a structured, hierarchical TODO plan.
 
-4. Produce a PRD-like section covering:
-   • Feature description and rationale.
-   • Functional requirements.
-   • Non-functional requirements (performance, scalability, security, compliance).
-   • User interaction flows (if applicable).
-   • Edge cases and failure scenarios.
+   - Break the task into atomic, verifiable subtasks.
+   - Ensure each subtask has a clear input, process, and expected output.
+   - Group subtasks into logical phases or categories.
+   - Explicitly state dependencies and opportunities for parallel execution.
 
-5. Apply quality enforcement rules:
-   • Avoid vague language, subjective terms, or implied assumptions.
-   • Every step must be actionable without external interpretation.
-   • Maintain consistency of terminology and format throughout.
+1. Enrich each subtask with execution metadata.
 
-6. Output format:
-   • Primary: Machine- and human-readable Markdown with tables, lists, and headings.
-   • Alternative (on request): JSON schema for direct ingestion by automation systems.
+   - Priority (High / Medium / Low).
+   - Effort estimate (time or complexity score).
+   - Required tools, frameworks, APIs, or datasets.
+   - Expected acceptance criteria and verification methods.
+
+1. Produce a PRD-like section covering:
+
+   - Feature description and rationale.
+   - Functional requirements.
+   - Non-functional requirements (performance, scalability, security, compliance).
+   - User interaction flows (if applicable).
+   - Edge cases and failure scenarios.
+
+1. Apply quality enforcement rules:
+
+   - Avoid vague language, subjective terms, or implied assumptions.
+   - Every step must be actionable without external interpretation.
+   - Maintain consistency of terminology and format throughout.
+
+1. Output format:
+
+   - Primary: Machine- and human-readable Markdown with tables, lists, and headings.
+   - Alternative (on request): JSON schema for direct ingestion by automation systems.
 
 Goal: Deliver a flawless, dependency-aware, and execution-ready plan that can be directly handed to one or more LLM agents to complete the task from start to finish without further clarification.

--- a/DOCS/RULES/02_TDD_XP_Workflow.md
+++ b/DOCS/RULES/02_TDD_XP_Workflow.md
@@ -4,6 +4,7 @@
 You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
 
 ## Guiding Principles
+
 - **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components only when driven by failing tests at the current level.
 - **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build, tests, and deployment pipeline passing.
 - **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are acceptable only as placeholders that immediately fail and motivate implementation.
@@ -11,56 +12,63 @@ You are an autonomous engineering agent practicing Extreme Programming with full
 - **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest iterations.
 
 ## Phase Overview
+
 1. **Initialize the Delivery Skeleton**
    - Create repository structure, build configuration, package metadata, and dependency management files.
    - Add continuous integration workflow (e.g., GitHub Actions) that runs the build, static checks, and the test suite.
    - Configure automated release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes), even if artifacts are placeholders.
    - Commit minimal executable code that compiles and runs without performing business logic.
 
-2. **Author High-Level Acceptance Tests**
+1. **Author High-Level Acceptance Tests**
    - Define end-to-end or service-level tests expressing the primary behavior from a user or system perspective.
    - Initially, tests may interact with CLI, API endpoints, or service boundaries that return canned or mock responses.
    - Acceptance tests should currently fail, documenting the desired capabilities before implementation.
 
-3. **Drive Implementation Outside-In**
+1. **Drive Implementation Outside-In**
    - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing deeper collaborators.
    - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to describe the required collaboration.
    - Repeat recursively: move downward only when higher-level expectations demand concrete behavior.
    - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing tests.
 
-4. **Refinement and Refactoring Cycle**
+1. **Refinement and Refactoring Cycle**
    - After each green build, refactor to remove duplication, clarify intent, and improve design.
    - Maintain strict test coverage for all refactorings; no functionality changes without failing tests first.
    - Continuously evolve test suites: upgrade placeholder assertions into meaningful expectations as features solidify.
 
-5. **Deployment and Release Readiness**
+1. **Deployment and Release Readiness**
    - Ensure CI pipelines produce deployable artifacts on every run.
    - Maintain versioning and changelog automation so that each merged change can be released without manual intervention.
    - Periodically execute a dry-run deployment to validate scripts and infrastructure.
 
 ## Iteration Template
+
 1. Pick the highest-priority failing acceptance test.
-2. Write/adjust a lower-level test that exposes the missing behavior.
-3. Implement the simplest code to satisfy the new test.
-4. Run the entire test suite and CI-equivalent checks locally.
-5. Refactor while keeping tests green.
-6. Commit with descriptive message referencing the behavior enabled.
-7. Update release notes or documentation if external behavior changes.
+1. Write/adjust a lower-level test that exposes the missing behavior.
+1. Implement the simplest code to satisfy the new test.
+1. Run the entire test suite and CI-equivalent checks locally.
+1. Refactor while keeping tests green.
+1. Commit with descriptive message referencing the behavior enabled.
+1. Update release notes or documentation if external behavior changes.
 
 ## Documentation Expectations
+
 - Maintain a living architecture README that mirrors the current system boundaries.
 - For each iteration, record:
+
   - The acceptance test scenario addressed.
   - Newly introduced components or collaborators.
   - Refactorings performed and their rationale.
+
 - Keep developer onboarding instructions current with the evolving build and deployment process.
 
 ## Communication and Collaboration Norms
+
 - Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid asynchronous collaborators.
 - Use feature flags or configuration toggles when partially implementing features to keep the main branch deployable.
 - Prefer small, frequent commits and pull requests aligned with single acceptance scenarios.
 
 ## Definition of Done
+
 - All relevant tests (acceptance, integration, unit) pass locally and in CI.
 - Build, package, and release automation completes successfully with current changes.
 - Documentation and release notes reflect the implemented behavior.

--- a/DOCS/RULES/03_Next_Task_Selection.md
+++ b/DOCS/RULES/03_Next_Task_Selection.md
@@ -4,16 +4,18 @@
 Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master PRD and execution guides.
 
 ## Required Inputs
+
 - `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for the authoritative task list, priorities, and dependencies.
 - `DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md` to confirm scope and acceptance expectations.
 - The `DOCS/INPROGRESS/` directory (if present) to avoid duplicating tasks already underway.
 - Repository state indicators (tests, CI status) to verify prerequisite tasks are actually complete.
 
 ## Selection Steps
+
 1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a document inside `DOCS/INPROGRESS/`.
-2. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks) or there is explicit documentation marking it complete.
-3. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
-4. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps, etc.). If blockers exist, return to step 3 with the next candidate.
-5. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
+1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks) or there is explicit documentation marking it complete.
+1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
+1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps, etc.). If blockers exist, return to step 3 with the next candidate.
+1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
 
 Following these steps keeps execution aligned with the strategic backlog while preventing conflicting workstreams.

--- a/DOCS/RULES/04_PDD.md
+++ b/DOCS/RULES/04_PDD.md
@@ -5,8 +5,7 @@ You are an **AI Coding Agent** working strictly by the principles of
 ([PDD in Action](https://www.yegor256.com/2017/04/05/pdd-in-action.html),  
 [Puzzle Driven Development](https://www.yegor256.com/2010/03/04/pdd.html)).
 
-Your workflow must ensure that **the code is the single source of truth**  
-and that `todo.md` is automatically synchronized from `@todo` comments.
+Your workflow must ensure that **the code is the single source of truth** and that `todo.md` is automatically synchronized from `@todo` comments.
 
 ## ✅ Rules
 
@@ -18,9 +17,11 @@ and that `todo.md` is automatically synchronized from `@todo` comments.
 ### 2. Puzzle Format in Code
 
 - Use the format:
+
   ```java
   // @todo #123 Short description of missing work
   ```
+
 - Keep puzzles small, actionable, and located exactly where the missing logic belongs.
 - Include enough context for another developer (or agent) to implement the task later.
 
@@ -33,16 +34,21 @@ and that `todo.md` is automatically synchronized from `@todo` comments.
 
 - Treat code as the only source of truth for tasks.
 - After each iteration:
-1. Parse all @todo comments in the code.
-2. Generate or update a single todo.md file at the repository root.
-3. In todo.md, represent each puzzle as a task with a checkbox:
-```markdown
-- [ ] #123 Short description
-```
-4. When a puzzle is removed from code, it must be marked as done in todo.md:
-```markdown
-- [x] #123 Short description
-```
+
+  1. Parse all @todo comments in the code.
+  1. Generate or update a single todo.md file at the repository root.
+  1. In todo.md, represent each puzzle as a task with a checkbox:
+
+     ```markdown
+     - [ ] #123 Short description
+     ```
+
+  1. When a puzzle is removed from code, it must be marked as done in todo.md:
+
+     ```markdown
+     - [x] #123 Short description
+     ```
+
 - Never update todo.md directly without checking the code first.
 
 ### 5. Workflow with todo.md
@@ -54,25 +60,30 @@ and that `todo.md` is automatically synchronized from `@todo` comments.
 #### 🔧 Example Workflow
 
 1. Developer assigns: Implement basic login feature.
-2. Agent writes:
-```
-class LoginService {
-    // minimal stub
-    boolean authenticate(String user, String pass) {
-        // @todo #101 Implement real authentication with DB
-        return true;
-    }
-}
-```
-3. Agent commits the code.
-4. Agent updates todo.md:
-  ```markdown
-- [ ] #101 Implement real authentication with DB
-  ```
-5. Later, when puzzle #101 is implemented and @todo removed, the agent updates todo.md:
-  ```markdown
-- [x] #101 Implement real authentication with DB
-```
+1. Agent writes:
+
+   ```java
+   class LoginService {
+       // minimal stub
+       boolean authenticate(String user, String pass) {
+           // @todo #101 Implement real authentication with DB
+           return true;
+       }
+   }
+   ```
+
+1. Agent commits the code.
+1. Agent updates todo.md:
+
+   ```markdown
+   - [ ] #101 Implement real authentication with DB
+   ```
+
+1. Later, when puzzle #101 is implemented and @todo removed, the agent updates todo.md:
+
+   ```markdown
+   - [x] #101 Implement real authentication with DB
+   ```
 
 ## 🎯 Principles
 


### PR DESCRIPTION
## Summary
- add a markdownlint configuration that relaxes the line-length rule while enforcing structural checks
- normalize command prompts to include blank lines around headings, lists, and code blocks, and add languages to fenced snippets
- adjust rules documents to include consistent headings, ordered list formatting, and final newlines

## Testing
- `npx markdownlint-cli "**/*.md"` *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e256e353e08321acfc9bb2997cd1e7