### PR TITLE
Fix markdown lint issues across documentation

### DIFF
--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -1,11 +1,13 @@
 # SYSTEM PROMPT: Archive Current Work-in-Progress
 
 ## 🧩 PURPOSE
+
 Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE), while preserving workflow continuity by detecting and carrying forward “next task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
 
 ---
 
 ## 🎯 GOAL
+
 Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder and automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references upcoming tasks.
 
 ---
@@ -31,6 +33,7 @@ DOCS/
       ├── 01_Initial_Setup
       ├── 02_Setup_Swift_SPM
       └── ...
+
 ```
 
 ---
@@ -58,6 +61,7 @@ DOCS/
   ```
 
   Example: `02_Setup_Swift_SPM`
+
 - Find the highest existing prefix `{NN}`, increment it by one to define the new folder name, e.g. `03_New_Task_Name`.
 
 - If [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE) does not exist, create it.
@@ -101,6 +105,7 @@ DOCS/
 ## 🧠 EXAMPLE
 
 **Before:**
+
 ```text
 DOCS/
  ├── INPROGRESS/
@@ -109,9 +114,11 @@ DOCS/
  └── TASK_ARCHIVE/
       ├── 01_Initial_Setup
       └── 02_Setup_Swift_SPM
+
 ```
 
 **After:**
+
 ```text
 DOCS/
  ├── INPROGRESS/
@@ -120,6 +127,7 @@ DOCS/
       ├── 01_Initial_Setup
       ├── 02_Setup_Swift_SPM
       └── 03_Current_Work
+
 ```
 
 ---

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -1,11 +1,13 @@
 # SYSTEM PROMPT: Select the Next Task
 
 ## 🧩 PURPOSE
+
 Automatically determine and initialize the next task to work on, following the predefined project rules and available task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the authoritative TODO sources.
 
 ---
 
 ## 🎯 GOAL
+
 Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md), analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
 
 ---
@@ -53,9 +55,11 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
   DOCS/INPROGRESS/03_Implement_New_Feature.md
   ```
 
-- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and guides located in other DOCS subfolders.
+- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and
+  guides located in other DOCS subfolders.
 
 ### Step 5. PRD Content Template
+
 The created file should include the following structure:
 
 ```markdown
@@ -79,7 +83,9 @@ Any key hints or dependencies to consider.
 - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [`DOCS/RULES/`](../RULES)
 - Any relevant archived context in [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)
+
 ```
+
 - Keep it short, structured, and clear.
 
 ### Step 6. Report Result
@@ -109,6 +115,7 @@ DOCS/
  │    └── next_tasks.md
  └── PRD/
       └── main_prd.md
+
 ```
 
 **After:**
@@ -122,11 +129,13 @@ DOCS/
  │    └── 03_Implement_New_Feature.md
  └── PRD/
       └── main_prd.md
+
 ```
 
 ---
 
 ## 🧾 NOTES
+
 - Always prioritize based on the formal rules in `DOCS/RULES`.
 - Use `next_tasks.md` as the primary source of candidates.
 - Ensure consistent file naming (prefix numbers if applicable).

--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -1,11 +1,13 @@
 # SYSTEM PROMPT: Start a New Task
 
 ## 🧩 PURPOSE
+
 Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established development rules, methodologies, and documentation dependencies.
 
 ---
 
 ## 🎯 GOAL
+
 Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and **XP (Extreme Programming)** principles.
 Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md).
 
@@ -116,6 +118,7 @@ DOCS/
  │    └── 04_PDD.md
  ├── PRD/
  │    └── main_prd.md
+
 ```
 
 **After:**
@@ -133,6 +136,7 @@ DOCS/
  │    └── 04_PDD.md
  └── PRD/
       └── main_prd.md
+
 ```
 
 ---

--- a/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
+++ b/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
@@ -1,27 +1,37 @@
 # B3 — Streaming Parse Pipeline
 
 ## 🎯 Objective
-Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a context stack so downstream consumers (UI, CLI, validation) can react incrementally.
+
+Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a
+context stack so downstream consumers (UI, CLI, validation) can react incrementally.
 
 ## 🧩 Context
+
 - Builds upon the core parser scope in the ISOInspector Technical Spec (`Core.Parser`, event model, context stack).
 - Aligns with master PRD goals for ISOInspectorCore to provide low-latency, low-memory streaming of large files.
 - Follows Execution Workplan Phase B progression after completing the box header decoder (B2).
 
 ## ✅ Success Criteria
-- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per specification.
+
+- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per
+  specification.
 - Event stream maintains parent/child context via explicit stack without recursion depth issues.
 - Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than crashing.
 - XCTest coverage proves deterministic event ordering and error handling across nominal and malformed inputs.
 
 ## 🔧 Implementation Notes
+
 - Use `RandomAccessReader` and `BoxHeaderDecoder` from B1/B2 as the foundation for reading headers and payload ranges.
 - Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure thread safety with Swift concurrency primitives.
-- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload boundaries.
-- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when possible.
-- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing test utilities.
+- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload
+  boundaries.
+- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when
+  possible.
+- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing
+  test utilities.
 
 ## 🧠 Source References
+
 - DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md
 - DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md
 - DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md

--- a/DOCS/INPROGRESS/F1_Test_Fixtures.md
+++ b/DOCS/INPROGRESS/F1_Test_Fixtures.md
@@ -1,27 +1,39 @@
 # F1 — Automated Test Fixture Suite
 
 ## 🎯 Objective
-Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed structures so the parser, validators, and exporters can be regression-tested automatically.
+
+Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed
+structures so the parser, validators, and exporters can be regression-tested automatically.
 
 ## 🧩 Context
-- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream modules have reliable coverage of positive and negative cases.
-- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets and licensing checks required before implementation.
-- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate boundary conditions noted in the technical specification.
+
+- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream
+  modules have reliable coverage of positive and negative cases.
+- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets
+  and licensing checks required before implementation.
+- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate
+  boundary conditions noted in the technical specification.
 
 ## ✅ Success Criteria
+
 - Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`, and intentionally malformed headers.
-- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored alongside the files for automated validation.
+- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored
+  alongside the files for automated validation.
 - `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes for both success and failure cases.
 - Documentation explains sourcing/licensing for every file and the process to refresh or regenerate fixtures.
 
 ## 🔧 Implementation Notes
-- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative files when licensing permits.
-- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in Python as outlined in the AI Source Guide toolchain.
+
+- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative
+  files when licensing permits.
+- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in
+  Python as outlined in the AI Source Guide toolchain.
 - Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and detect drift.
 - Define helper utilities (e.g., `FixtureCatalog`) that expose fixture metadata to tests and future benchmarks (F2) without hard-coding paths.
 - Anticipate reuse by CLI/UI teams by documenting fixture semantics in DocC or Guides for cross-team visibility.
 
 ## 🧠 Source References
+
 - DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md
 - DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md
 - DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md

--- a/DOCS/RULES/01_PRD.md
+++ b/DOCS/RULES/01_PRD.md
@@ -1,6 +1,9 @@
 # PRD Authoring Rules
 
-System: You are an expert project analyst and specification architect, specialized in creating implementation-ready technical assignments (Tech Specs), actionable TODO breakdowns, and complete PRD (Product Requirements Documents) tailored for execution by LLM-based agents. Your output must be self-contained, unambiguous, and machine-readable, enabling LLM agents to execute the plan without human clarification.
+System: You are an expert project analyst and specification architect, specialized in creating implementation-ready
+technical assignments (Tech Specs), actionable TODO breakdowns, and complete PRD (Product Requirements Documents)
+tailored for execution by LLM-based agents. Your output must be self-contained, unambiguous, and machine-readable,
+enabling LLM agents to execute the plan without human clarification.
 
 For each provided high-level goal or idea:
 
@@ -43,4 +46,5 @@ For each provided high-level goal or idea:
    - Primary: Machine- and human-readable Markdown with tables, lists, and headings.
    - Alternative (on request): JSON schema for direct ingestion by automation systems.
 
-Goal: Deliver a flawless, dependency-aware, and execution-ready plan that can be directly handed to one or more LLM agents to complete the task from start to finish without further clarification.
+Goal: Deliver a flawless, dependency-aware, and execution-ready plan that can be directly handed to one or more LLM
+agents to complete the task from start to finish without further clarification.

--- a/DOCS/RULES/02_TDD_XP_Workflow.md
+++ b/DOCS/RULES/02_TDD_XP_Workflow.md
@@ -1,22 +1,31 @@
 # XP-Inspired TDD Workflow (Outside-In)
 
 ## Mission Statement
-You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
+
+You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is
+to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest
+architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
 
 ## Guiding Principles
 
-- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components only when driven by failing tests at the current level.
-- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build, tests, and deployment pipeline passing.
-- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are acceptable only as placeholders that immediately fail and motivate implementation.
-- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify design while keeping feedback loops tight.
-- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest iterations.
+- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components
+  only when driven by failing tests at the current level.
+- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build,
+  tests, and deployment pipeline passing.
+- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are
+  acceptable only as placeholders that immediately fail and motivate implementation.
+- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify
+  design while keeping feedback loops tight.
+- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest
+  iterations.
 
 ## Phase Overview
 
 1. **Initialize the Delivery Skeleton**
    - Create repository structure, build configuration, package metadata, and dependency management files.
    - Add continuous integration workflow (e.g., GitHub Actions) that runs the build, static checks, and the test suite.
-   - Configure automated release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes), even if artifacts are placeholders.
+   - Configure automated release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes), even
+     if artifacts are placeholders.
    - Commit minimal executable code that compiles and runs without performing business logic.
 
 1. **Author High-Level Acceptance Tests**
@@ -25,10 +34,13 @@ You are an autonomous engineering agent practicing Extreme Programming with full
    - Acceptance tests should currently fail, documenting the desired capabilities before implementation.
 
 1. **Drive Implementation Outside-In**
-   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing deeper collaborators.
-   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to describe the required collaboration.
+   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing
+     deeper collaborators.
+   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to
+     describe the required collaboration.
    - Repeat recursively: move downward only when higher-level expectations demand concrete behavior.
-   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing tests.
+   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing
+     tests.
 
 1. **Refinement and Refactoring Cycle**
    - After each green build, refactor to remove duplication, clarify intent, and improve design.
@@ -37,7 +49,8 @@ You are an autonomous engineering agent practicing Extreme Programming with full
 
 1. **Deployment and Release Readiness**
    - Ensure CI pipelines produce deployable artifacts on every run.
-   - Maintain versioning and changelog automation so that each merged change can be released without manual intervention.
+   - Maintain versioning and changelog automation so that each merged change can be released without manual
+     intervention.
    - Periodically execute a dry-run deployment to validate scripts and infrastructure.
 
 ## Iteration Template
@@ -63,7 +76,8 @@ You are an autonomous engineering agent practicing Extreme Programming with full
 
 ## Communication and Collaboration Norms
 
-- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid asynchronous collaborators.
+- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid
+  asynchronous collaborators.
 - Use feature flags or configuration toggles when partially implementing features to keep the main branch deployable.
 - Prefer small, frequent commits and pull requests aligned with single acceptance scenarios.
 

--- a/DOCS/RULES/03_Next_Task_Selection.md
+++ b/DOCS/RULES/03_Next_Task_Selection.md
@@ -1,7 +1,9 @@
 # Next Task Selection Rules
 
 ## Purpose
-Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master PRD and execution guides.
+
+Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master
+PRD and execution guides.
 
 ## Required Inputs
 
@@ -15,7 +17,8 @@ Ensure each new work item advances the product backlog in a controlled, dependen
 1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a document inside `DOCS/INPROGRESS/`.
 1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks) or there is explicit documentation marking it complete.
 1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
-1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps, etc.). If blockers exist, return to step 3 with the next candidate.
+1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps,
+   etc.). If blockers exist, return to step 3 with the next candidate.
 1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
 
 Following these steps keeps execution aligned with the strategic backlog while preventing conflicting workstreams.

--- a/DOCS/RULES/04_PDD.md
+++ b/DOCS/RULES/04_PDD.md
@@ -40,13 +40,17 @@ Your workflow must ensure that **the code is the single source of truth** and th
   1. In todo.md, represent each puzzle as a task with a checkbox:
 
      ```markdown
+
      - [ ] #123 Short description
+
      ```
 
   1. When a puzzle is removed from code, it must be marked as done in todo.md:
 
      ```markdown
+
      - [x] #123 Short description
+
      ```
 
 - Never update todo.md directly without checking the code first.
@@ -76,13 +80,17 @@ Your workflow must ensure that **the code is the single source of truth** and th
 1. Agent updates todo.md:
 
    ```markdown
+
    - [ ] #101 Implement real authentication with DB
+
    ```
 
 1. Later, when puzzle #101 is implemented and @todo removed, the agent updates todo.md:
 
    ```markdown
+
    - [x] #101 Implement real authentication with DB
+
    ```
 
 ## 🎯 Principles

--- a/scripts/fix_markdown.py
+++ b/scripts/fix_markdown.py
@@ -1,0 +1,193 @@
+import re
+from pathlib import Path
+
+# ---- Настройки ----
+GLOBS = [
+    "DOCS/INPROGRESS/**/*.md",
+    "DOCS/COMMANDS/**/*.md",
+    "DOCS/RULES/**/*.md",
+]
+LINE_LIMIT = 120
+
+# Регексы
+RE_HEADING = re.compile(r"^(#{1,6})\s+")
+RE_UL = re.compile(r"^([ \t]*)([-+*])\s+")
+RE_OL = re.compile(r"^([ \t]*)(\d+)\.\s+")
+RE_FENCE = re.compile(r"^```")
+RE_TABLE = re.compile(r"^\s*\|")      # простая эвристика таблиц
+RE_QUOTE = re.compile(r"^\s*>\s")     # цитаты
+RE_URL = re.compile(r"https?://\S+")
+RE_INLINE_CODE = re.compile(r"`[^`]*`")
+
+
+def normalize_newlines(text: str) -> str:
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = re.sub(r"\s+\Z", "", text)  # срезаем хвостовые пробелы/переводы
+    return text + "\n"                 # ровно один \n в конце (MD047)
+
+
+def is_list_line(s: str) -> bool:
+    return bool(RE_UL.match(s) or RE_OL.match(s))
+
+
+def wrap_line(s: str, limit: int) -> list[str]:
+    # Не переносим строки, если есть URL или инлайн-код (чтобы не ломать)
+    if len(s) <= limit or RE_URL.search(s) or RE_INLINE_CODE.search(s):
+        return [s]
+    # мягкий перенос по пробелам
+    out, cur = [], []
+    length = 0
+    words = re.split(r"(\s+)", s)  # сохраняем пробелы как токены
+    for w in words:
+        wlen = len(w)
+        if length + wlen > limit and cur:
+            out.append("".join(cur).rstrip())
+            cur = [w.lstrip()]
+            length = len(cur[0])
+        else:
+            cur.append(w)
+            length += wlen
+    if cur:
+        out.append("".join(cur).rstrip())
+    return out
+
+
+def process_file(path: Path) -> bool:
+    raw = path.read_text(encoding="utf-8")
+    text = normalize_newlines(raw)
+    lines = text.split("\n")
+
+    # Первая проходка: добавить пустые строки вокруг заголовков и фенсов
+    out = []
+    in_fence = False
+    for i, line in enumerate(lines):
+        next_line = lines[i + 1] if i + 1 < len(lines) else ""
+
+        if RE_FENCE.match(line):
+            if out and out[-1] != "":
+                out.append("")
+            out.append(line)
+            in_fence = not in_fence
+            continue
+
+        if RE_HEADING.match(line) and not in_fence:
+            if out and out[-1] != "":
+                out.append("")
+            out.append(line)
+            if next_line != "" and not RE_FENCE.match(next_line):
+                out.append("")
+            continue
+
+        out.append(line)
+
+    lines = out
+
+    # Вторая проходка: пустые строки вокруг списков и после закрывающих фенсов
+    out = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if RE_FENCE.match(line):
+            if in_fence:
+                out.append(line)
+                in_fence = False
+                if i + 1 < len(lines) and lines[i + 1] != "":
+                    out.append("")
+            else:
+                out.append(line)
+                in_fence = True
+            i += 1
+            continue
+
+        if not in_fence and is_list_line(line):
+            if out and out[-1] != "":
+                out.append("")
+            j = i
+            while j < len(lines) and is_list_line(lines[j]):
+                out.append(lines[j])
+                j += 1
+            if j < len(lines) and lines[j] != "":
+                out.append("")
+            i = j
+            continue
+
+        out.append(line)
+        i += 1
+
+    lines = out
+
+    # Третья проходка: перенос длинных строк (MD013)
+    out = []
+    in_fence = False
+    for line in lines:
+        if RE_FENCE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence or RE_TABLE.match(line) or RE_QUOTE.match(line):
+            out.append(line)
+            continue
+
+        if RE_HEADING.match(line):
+            out.append(line)
+            continue
+
+        m_ul = RE_UL.match(line)
+        m_ol = RE_OL.match(line)
+        if m_ul:
+            indent, bullet = m_ul.groups()
+            body = line[m_ul.end():].strip()
+            wrapped = wrap_line(body, LINE_LIMIT - len(indent) - len(bullet) - 1)
+            if wrapped:
+                out.append(f"{indent}{bullet} {wrapped[0]}")
+                for w in wrapped[1:]:
+                    out.append(f"{indent}  {w}")
+            else:
+                out.append(line)
+            continue
+        if m_ol:
+            indent, num = m_ol.groups()
+            body = line[m_ol.end():].strip()
+            prefix = f"{indent}1."
+            wrapped = wrap_line(body, LINE_LIMIT - len(prefix) - 1)
+            if wrapped:
+                out.append(f"{prefix} {wrapped[0]}")
+                for w in wrapped[1:]:
+                    out.append(f"{indent}   {w}")
+            else:
+                out.append(f"{prefix} {body}" if body else f"{prefix}")
+            continue
+
+        if len(line) > LINE_LIMIT:
+            for w in wrap_line(line, LINE_LIMIT):
+                out.append(w)
+        else:
+            out.append(line)
+
+    fixed = "\n".join(out)
+    fixed = normalize_newlines(fixed)
+
+    if fixed != raw:
+        path.write_text(fixed, encoding="utf-8")
+        return True
+    return False
+
+
+def main():
+    changed = 0
+    files: list[Path] = []
+    for g in GLOBS:
+        files += list(Path(".").glob(g))
+    files = [p for p in files if p.is_file()]
+
+    for p in files:
+        if process_file(p):
+            changed += 1
+            print(f"fixed: {p}")
+
+    print(f"done. files changed: {changed}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an idempotent Python helper to normalize markdown formatting for DOCS content
- apply the helper to bring DOCS markdown files in line with markdownlint expectations

## Testing
- python3 scripts/fix_markdown.py
- npx markdownlint-cli2 "DOCS/INPROGRESS/**/*.md" "DOCS/COMMANDS/**/*.md" "DOCS/RULES/**/*.md" *(fails: npm error code E403 fetching markdownlint-cli2)*

------
https://chatgpt.com/codex/tasks/task_e_68e2596f044c8321b2134d9b99bb8987