### PR TITLE
Wrap Markdown documentation to 120 columns

### DIFF
--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -2,20 +2,25 @@
 
 ## 🧩 PURPOSE
 
-Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE), while preserving workflow continuity by detecting and carrying forward “next task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
+Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [
+`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE), while preserving workflow continuity by detecting and carrying forward “next
+task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
 
 ---
 
 ## 🎯 GOAL
 
-Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder and automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references upcoming tasks.
+Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder
+and automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references
+upcoming tasks.
 
 ---
 
 ## 🔗 REFERENCE MATERIALS
 
 - [Root TODO list (`todo.md`)](../../todo.md)
-- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
+  )](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
 - [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
 - [Backlog detail (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [Archive index (`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`)](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md)
@@ -42,13 +47,17 @@ DOCS/
 
 ### Step 1. Inspect Current Work Folder
 
-- Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and `F1_Test_Fixtures.md`).
+- Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and
+  `F1_Test_Fixtures.md`).
 - Detect any file whose name **contains “Summary”** (such as a `Summary_of_Work.md`) or is exactly **`next_tasks.md`**.
 - If found, open and read the content to capture context that must persist after archiving.
 
 ### Step 2. Extract Mentions of Upcoming Tasks
 
-- Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
+- Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [
+  `DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [
+  `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+  and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 - If found, temporarily store this information to recreate it later.
 
 ### Step 3. Determine the Next Archive Folder Name
@@ -71,7 +80,8 @@ DOCS/
 
 - Move **all files and subfolders** from [`DOCS/INPROGRESS`](../INPROGRESS) to the new archive folder.
 - Preserve structure and file integrity.
-- Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if it requires a new entry for the archived task set.
+- Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if it requires a new entry for the
+  archived task set.
 
 ### Step 6. Recreate `next_tasks.md` (if applicable)
 
@@ -83,13 +93,17 @@ DOCS/
     DOCS/INPROGRESS/next_tasks.md
     ```
 
-  - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items tracked in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
+  - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items
+    tracked in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
+    ](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`
+    ](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 
 ### Step 7. Report Result
 
 - Output the **path of the new archive folder**.
 - Indicate whether a **new `next_tasks.md`** file was created.
-- Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [`todo.md`](../../todo.md).
+- Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [
+  `todo.md`](../../todo.md).
 
 ---
 

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -2,21 +2,30 @@
 
 ## 🧩 PURPOSE
 
-Automatically determine and initialize the next task to work on, following the predefined project rules and available task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the authoritative TODO sources.
+Automatically determine and initialize the next task to work on, following the predefined project rules and available
+task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the
+authoritative TODO sources.
 
 ---
 
 ## 🎯 GOAL
 
-Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md), analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
+Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md),
+analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task
+document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution
+workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD
+backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master
+PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
 
 ---
 
 ## 🔗 REFERENCE MATERIALS
 
 - [Root TODO list (`todo.md`)](../../todo.md)
-- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-- [Master PRD (`DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`)](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
+  )](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Master PRD (`DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`
+  )](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
 - [Detailed backlog (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
 - [Workflow rules (`DOCS/RULES/02_TDD_XP_Workflow.md`)](../RULES/02_TDD_XP_Workflow.md)
@@ -27,14 +36,17 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
 
 ### Step 1. Read Task Selection Rules
 
-- Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and dependency logic.
-- Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
+- Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and
+  dependency logic.
+- Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and
+  product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
 - Parse and understand the criteria before evaluating candidates.
 
 ### Step 2. Inspect Pending Tasks
 
 - Check if [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) exists.
-- If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over `B2+` streaming interface item.
+- If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over
+  `B2+` streaming interface item.
 
 ### Step 3. Apply Selection Rules
 
@@ -42,8 +54,10 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
 - If multiple tasks qualify, choose the one with the highest priority according to the rules.
 - If no tasks are found in `next_tasks.md`, consult the broader backlog sources:
 
-  - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) for the authoritative workplan.
-  - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5) Detailed TODO (execution-ready, без кода)" section.
+  - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+    for the authoritative workplan.
+  - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5)
+    Detailed TODO (execution-ready, без кода)" section.
   - The root [`todo.md`](../../todo.md) for any repo-level quick wins.
 
 ### Step 4. Create a New Task Document
@@ -98,7 +112,8 @@ Any key hints or dependencies to consider.
 ## ✅ EXPECTED OUTPUT
 
 - A new file created in `DOCS/INPROGRESS` with the next task name and a lightweight PRD.
-- The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`](../INPROGRESS/next_tasks.md) and the backlog sources linked above.
+- The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`
+  ](../INPROGRESS/next_tasks.md) and the backlog sources linked above.
 - A short summary confirming the selected task and the applied rules.
 
 ---

--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -2,14 +2,18 @@
 
 ## 🧩 PURPOSE
 
-Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established development rules, methodologies, and documentation dependencies.
+Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established
+development rules, methodologies, and documentation dependencies.
 
 ---
 
 ## 🎯 GOAL
 
-Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and **XP (Extreme Programming)** principles.
-Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md).
+Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering
+standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and
+**XP (Extreme Programming)** principles.
+Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`
+](../RULES/04_PDD.md).
 
 ---
 
@@ -26,7 +30,8 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 - Open the folder [`DOCS/RULES/`](../RULES).
 - Pay special attention to:
 
-  - [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — test-first principles and verification steps, pair programming, refactoring, and incremental delivery.
+  - [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — test-first principles and verification steps,
+    pair programming, refactoring, and incremental delivery.
   - [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md) — workflow for Puzzle-Driven Development.
 
 - Keep these rules in mind during all implementation actions.
@@ -35,8 +40,10 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 
 - If needed, consult files in other subfolders under `DOCS/`:
 
-  - [`DOCS/AI/ISOViewer`](../AI/ISOViewer) – main product requirements (e.g., [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
-  - [`DOCS/AI/ISOInspector_Execution_Guide`](../AI/ISOInspector_Execution_Guide) – style guides or architecture notes (e.g., [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)).
+  - [`DOCS/AI/ISOViewer`](../AI/ISOViewer) – main product requirements (e.g., [`ISOInspector_Master_PRD.md`
+    ](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
+  - [`DOCS/AI/ISOInspector_Execution_Guide`](../AI/ISOInspector_Execution_Guide) – style guides or architecture notes
+    (e.g., [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)).
   - [`DOCS/MP4_Specs`](../MP4_Specs) – interface or API specifications.
 
 - Use them to clarify edge cases or functional expectations.
@@ -63,7 +70,9 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 ### Step 5. Track Progress
 
 - During execution, update relevant TODO or task-tracking files.
-- When a puzzle or task is completed, **mark it as done** in the corresponding todo list in [`DOCS/AI/ISOViewer`](../AI/ISOViewer) (such as [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other status list.
+- When a puzzle or task is completed, **mark it as done** in the corresponding todo list in [`DOCS/AI/ISOViewer`
+  ](../AI/ISOViewer) (such as [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other
+  status list.
 
 ### Step 6. Write Summary
 
@@ -97,7 +106,8 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 
 - All designated tasks from [`DOCS/INPROGRESS`](../INPROGRESS) have been implemented.
 - Corresponding entries in [`todo.md`](../../todo.md) and related files are marked as completed.
-- A new file [`Summary_of_Work.md`](../INPROGRESS/Summary_of_Work.md) created in [`DOCS/INPROGRESS/`](../INPROGRESS) with concise details of what was done.
+- A new file [`Summary_of_Work.md`](../INPROGRESS/Summary_of_Work.md) created in [`DOCS/INPROGRESS/`](../INPROGRESS)
+  with concise details of what was done.
 - No untracked changes remain.
 
 ---

--- a/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
+++ b/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
@@ -16,13 +16,15 @@ context stack so downstream consumers (UI, CLI, validation) can react incrementa
 - Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per
   specification.
 - Event stream maintains parent/child context via explicit stack without recursion depth issues.
-- Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than crashing.
+- Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than
+  crashing.
 - XCTest coverage proves deterministic event ordering and error handling across nominal and malformed inputs.
 
 ## 🔧 Implementation Notes
 
 - Use `RandomAccessReader` and `BoxHeaderDecoder` from B1/B2 as the foundation for reading headers and payload ranges.
-- Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure thread safety with Swift concurrency primitives.
+- Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure
+  thread safety with Swift concurrency primitives.
 - Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload
   boundaries.
 - Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when

--- a/DOCS/INPROGRESS/F1_Test_Fixtures.md
+++ b/DOCS/INPROGRESS/F1_Test_Fixtures.md
@@ -16,10 +16,12 @@ structures so the parser, validators, and exporters can be regression-tested aut
 
 ## ✅ Success Criteria
 
-- Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`, and intentionally malformed headers.
+- Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`,
+  and intentionally malformed headers.
 - Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored
   alongside the files for automated validation.
-- `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes for both success and failure cases.
+- `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes
+  for both success and failure cases.
 - Documentation explains sourcing/licensing for every file and the process to refresh or regenerate fixtures.
 
 ## 🔧 Implementation Notes
@@ -28,8 +30,10 @@ structures so the parser, validators, and exporters can be regression-tested aut
   files when licensing permits.
 - Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in
   Python as outlined in the AI Source Guide toolchain.
-- Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and detect drift.
-- Define helper utilities (e.g., `FixtureCatalog`) that expose fixture metadata to tests and future benchmarks (F2) without hard-coding paths.
+- Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and
+  detect drift.
+- Define helper utilities (e.g., `FixtureCatalog`) that expose fixture metadata to tests and future benchmarks (F2)
+  without hard-coding paths.
 - Anticipate reuse by CLI/UI teams by documenting fixture semantics in DocC or Guides for cross-team visibility.
 
 ## 🧠 Source References

--- a/DOCS/RULES/03_Next_Task_Selection.md
+++ b/DOCS/RULES/03_Next_Task_Selection.md
@@ -7,18 +7,24 @@ PRD and execution guides.
 
 ## Required Inputs
 
-- `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for the authoritative task list, priorities, and dependencies.
+- `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for the authoritative task list, priorities, and
+  dependencies.
 - `DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md` to confirm scope and acceptance expectations.
 - The `DOCS/INPROGRESS/` directory (if present) to avoid duplicating tasks already underway.
 - Repository state indicators (tests, CI status) to verify prerequisite tasks are actually complete.
 
 ## Selection Steps
 
-1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a document inside `DOCS/INPROGRESS/`.
-1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks) or there is explicit documentation marking it complete.
-1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
+1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a
+   document inside `DOCS/INPROGRESS/`.
+1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as
+   satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks)
+   or there is explicit documentation marking it complete.
+1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`).
+   When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
 1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps,
    etc.). If blockers exist, return to step 3 with the next candidate.
-1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
+1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective,
+   scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
 
 Following these steps keeps execution aligned with the strategic backlog while preventing conflicting workstreams.

--- a/DOCS/RULES/04_PDD.md
+++ b/DOCS/RULES/04_PDD.md
@@ -5,7 +5,8 @@ You are an **AI Coding Agent** working strictly by the principles of
 ([PDD in Action](https://www.yegor256.com/2017/04/05/pdd-in-action.html),  
 [Puzzle Driven Development](https://www.yegor256.com/2010/03/04/pdd.html)).
 
-Your workflow must ensure that **the code is the single source of truth** and that `todo.md` is automatically synchronized from `@todo` comments.
+Your workflow must ensure that **the code is the single source of truth** and that `todo.md` is automatically
+synchronized from `@todo` comments.
 
 ## ✅ Rules
 


### PR DESCRIPTION
## Summary
- reflowed command prompts to respect the 120-character markdownlint limit without breaking links or list structure
- wrapped in-progress and rules documentation lines to comply with MD013 while preserving semantics

## Testing
- `npx markdownlint-cli2 "DOCS/INPROGRESS/**/*.md" "DOCS/COMMANDS/**/*.md" "DOCS/RULES/**/*.md"` *(fails: npm registry returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e25bc57f388321bbf1d63722cba931