### PR TITLE
Disable markdown line-length rule and unwrap documentation lists

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,12 +1,6 @@
 {
   "default": true,
-  "MD013": {
-    "line_length": 120,
-    "heading_line_length": 120,
-    "code_blocks": false,
-    "tables": false,
-    "strict": false
-  },
+  "MD013": false,
   "MD025": {
     "level": 1
   },

--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -2,27 +2,22 @@
 
 ## 🧩 PURPOSE
 
-Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [
-`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE), while preserving workflow continuity by detecting and carrying forward “next
-task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
+Archive the current contents of [`DOCS/INPROGRESS`](../INPROGRESS) into a sequentially numbered folder under [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE). Preserve workflow continuity by detecting and carrying forward “next task” references documented in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md).
 
 ---
 
 ## 🎯 GOAL
 
-Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder
-and automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references
-upcoming tasks.
+Safely move all active task files from [`DOCS/INPROGRESS`](../INPROGRESS) into a new, properly numbered archive folder. Automatically prepare a new [`next_tasks.md`](../INPROGRESS/next_tasks.md) file if the current summary references upcoming tasks.
 
 ---
 
 ## 🔗 REFERENCE MATERIALS
 
 - [Root TODO list (`todo.md`)](../../todo.md)
-- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
-  )](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-- [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
-- [Backlog detail (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [Execution workplan (04_TODO_Workplan.md)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Task selection rules (03_Next_Task_Selection.md)](../RULES/03_Next_Task_Selection.md)
+- [Backlog detail (ISOInspector_PRD_TODO.md)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [Archive index (`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`)](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md)
 
 ---
@@ -47,17 +42,13 @@ DOCS/
 
 ### Step 1. Inspect Current Work Folder
 
-- Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and
-  `F1_Test_Fixtures.md`).
+- Look inside [`DOCS/INPROGRESS`](../INPROGRESS) (e.g., the current task docs `B3_Streaming_Parse_Pipeline.md` and `F1_Test_Fixtures.md`).
 - Detect any file whose name **contains “Summary”** (such as a `Summary_of_Work.md`) or is exactly **`next_tasks.md`**.
 - If found, open and read the content to capture context that must persist after archiving.
 
 ### Step 2. Extract Mentions of Upcoming Tasks
 
-- Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [
-  `DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [
-  `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-  and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
+- Search the text for mentions of **pending**, **next**, or **upcoming** tasks. Prioritize any checklists in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) and cross-check against the broader backlog in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 - If found, temporarily store this information to recreate it later.
 
 ### Step 3. Determine the Next Archive Folder Name
@@ -80,8 +71,7 @@ DOCS/
 
 - Move **all files and subfolders** from [`DOCS/INPROGRESS`](../INPROGRESS) to the new archive folder.
 - Preserve structure and file integrity.
-- Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if it requires a new entry for the
-  archived task set.
+- Update [`DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) if a new entry is needed.
 
 ### Step 6. Recreate `next_tasks.md` (if applicable)
 
@@ -93,17 +83,13 @@ DOCS/
     DOCS/INPROGRESS/next_tasks.md
     ```
 
-  - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items
-    tracked in [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
-    ](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`
-    ](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
+  - Write the extracted list or short summary of those next tasks into it, ensuring they align with the backlog items tracked in [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) and [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md).
 
 ### Step 7. Report Result
 
 - Output the **path of the new archive folder**.
 - Indicate whether a **new `next_tasks.md`** file was created.
-- Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [
-  `todo.md`](../../todo.md).
+- Reference any updates made to [`ARCHIVE_SUMMARY.md`](../TASK_ARCHIVE/ARCHIVE_SUMMARY.md) or outstanding todos in [`todo.md`](../../todo.md).
 
 ---
 

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -2,31 +2,22 @@
 
 ## 🧩 PURPOSE
 
-Automatically determine and initialize the next task to work on, following the predefined project rules and available
-task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the
-authoritative TODO sources.
+Automatically determine and initialize the next task to work on, following the predefined project rules and available task notes from [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), the execution guide, and the authoritative TODO sources.
 
 ---
 
 ## 🎯 GOAL
 
-Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md),
-analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task
-document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution
-workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD
-backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master
-PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
+Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md), analyze pending tasks listed in [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md), and create a new task document containing its title and a lightweight PRD outline based on the main project documentation (see the [execution workplan](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md), [PRD backlog](../AI/ISOViewer/ISOInspector_PRD_TODO.md), and [master PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
 
 ---
 
 ## 🔗 REFERENCE MATERIALS
 
 - [Root TODO list (`todo.md`)](../../todo.md)
-- [Execution workplan (`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`
-  )](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-- [Master PRD (`DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`
-  )](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
-- [Detailed backlog (`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [Execution workplan (04_TODO_Workplan.md)](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [Master PRD (ISOInspector_Master_PRD.md)](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [Detailed backlog (ISOInspector_PRD_TODO.md)](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [Task selection rules (`DOCS/RULES/03_Next_Task_Selection.md`)](../RULES/03_Next_Task_Selection.md)
 - [Workflow rules (`DOCS/RULES/02_TDD_XP_Workflow.md`)](../RULES/02_TDD_XP_Workflow.md)
 
@@ -36,28 +27,22 @@ PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
 
 ### Step 1. Read Task Selection Rules
 
-- Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and
-  dependency logic.
-- Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and
-  product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
+- Open [`DOCS/RULES/03_Next_Task_Selection.md`](../RULES/03_Next_Task_Selection.md) for the explicit prioritization and dependency logic.
+- Review supporting workflow guidance in [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) and product framing notes in [`DOCS/RULES/01_PRD.md`](../RULES/01_PRD.md).
 - Parse and understand the criteria before evaluating candidates.
 
 ### Step 2. Inspect Pending Tasks
 
 - Check if [`DOCS/INPROGRESS/next_tasks.md`](../INPROGRESS/next_tasks.md) exists.
-- If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over
-  `B2+` streaming interface item.
+- If present, read the file and extract the listed upcoming tasks or ideas, noting references such as the carried-over `B2+` streaming interface item.
 
 ### Step 3. Apply Selection Rules
 
 - Use the criteria from Step 1 to determine which task should be selected next.
 - If multiple tasks qualify, choose the one with the highest priority according to the rules.
 - If no tasks are found in `next_tasks.md`, consult the broader backlog sources:
-
-  - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-    for the authoritative workplan.
-  - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5)
-    Detailed TODO (execution-ready, без кода)" section.
+  - [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) for the authoritative workplan.
+  - [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md) — especially the "## 5) Detailed TODO (execution-ready, без кода)" section.
   - The root [`todo.md`](../../todo.md) for any repo-level quick wins.
 
 ### Step 4. Create a New Task Document
@@ -69,8 +54,7 @@ PRD](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
   DOCS/INPROGRESS/03_Implement_New_Feature.md
   ```
 
-- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and
-  guides located in other DOCS subfolders.
+- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and guides located in other DOCS subfolders.
 
 ### Step 5. PRD Content Template
 
@@ -92,10 +76,10 @@ List of measurable completion conditions.
 Any key hints or dependencies to consider.
 
 ## 🧠 Source References
-- [`DOCS/AI/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
-- [`DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
-- [`DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
-- [`DOCS/RULES/`](../RULES)
+- [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [`DOCS/RULES`](../RULES)
 - Any relevant archived context in [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)
 
 ```
@@ -112,8 +96,7 @@ Any key hints or dependencies to consider.
 ## ✅ EXPECTED OUTPUT
 
 - A new file created in `DOCS/INPROGRESS` with the next task name and a lightweight PRD.
-- The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`
-  ](../INPROGRESS/next_tasks.md) and the backlog sources linked above.
+- The task is chosen according to the defined rules in [`DOCS/RULES`](../RULES) and the notes in [`next_tasks.md`](../INPROGRESS/next_tasks.md), plus the backlog sources linked above.
 - A short summary confirming the selected task and the applied rules.
 
 ---

--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -2,18 +2,13 @@
 
 ## 🧩 PURPOSE
 
-Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established
-development rules, methodologies, and documentation dependencies.
+Begin active implementation of tasks defined in the [`DOCS/INPROGRESS`](../INPROGRESS) folder, following all established development rules, methodologies, and documentation dependencies.
 
 ---
 
 ## 🎯 GOAL
 
-Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering
-standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and
-**XP (Extreme Programming)** principles.
-Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`
-](../RULES/04_PDD.md).
+Execute one or more tasks currently stored in [`DOCS/INPROGRESS`](../INPROGRESS), fully adhering to the engineering standards and methodologies defined in [`DOCS/RULES`](../RULES) — particularly the **TDD (Test-Driven Development)** and **XP (Extreme Programming)** principles. Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md).
 
 ---
 
@@ -30,21 +25,17 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 - Open the folder [`DOCS/RULES/`](../RULES).
 - Pay special attention to:
 
-  - [`DOCS/RULES/02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — test-first principles and verification steps,
-    pair programming, refactoring, and incremental delivery.
-  - [`DOCS/RULES/04_PDD.md`](../RULES/04_PDD.md) — workflow for Puzzle-Driven Development.
+  - [`02_TDD_XP_Workflow.md`](../RULES/02_TDD_XP_Workflow.md) — TDD flow, pairing, refactoring, incremental delivery.
+  - [`04_PDD.md`](../RULES/04_PDD.md) — puzzle-driven development workflow.
 
 - Keep these rules in mind during all implementation actions.
 
 ### Step 3. Gather Additional References
 
 - If needed, consult files in other subfolders under `DOCS/`:
-
-  - [`DOCS/AI/ISOViewer`](../AI/ISOViewer) – main product requirements (e.g., [`ISOInspector_Master_PRD.md`
-    ](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)).
-  - [`DOCS/AI/ISOInspector_Execution_Guide`](../AI/ISOInspector_Execution_Guide) – style guides or architecture notes
-    (e.g., [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)).
-  - [`DOCS/MP4_Specs`](../MP4_Specs) – interface or API specifications.
+  - [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md) — product scope.
+  - [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md) — style and architecture notes.
+  - [`DOCS/MP4_Specs`](../MP4_Specs) — interface or API specifications.
 
 - Use them to clarify edge cases or functional expectations.
 
@@ -70,9 +61,7 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 ### Step 5. Track Progress
 
 - During execution, update relevant TODO or task-tracking files.
-- When a puzzle or task is completed, **mark it as done** in the corresponding todo list in [`DOCS/AI/ISOViewer`
-  ](../AI/ISOViewer) (such as [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other
-  status list.
+- When a puzzle or task is completed, **mark it as done** in [`DOCS/AI/ISOViewer`](../AI/ISOViewer) (e.g., [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)) and in any other status list.
 
 ### Step 6. Write Summary
 
@@ -106,8 +95,7 @@ Additionally, follow the PDD (Puzzle-Driven Development) process defined in [`DO
 
 - All designated tasks from [`DOCS/INPROGRESS`](../INPROGRESS) have been implemented.
 - Corresponding entries in [`todo.md`](../../todo.md) and related files are marked as completed.
-- A new file [`Summary_of_Work.md`](../INPROGRESS/Summary_of_Work.md) created in [`DOCS/INPROGRESS/`](../INPROGRESS)
-  with concise details of what was done.
+- A new file [`Summary_of_Work.md`](../INPROGRESS/Summary_of_Work.md) created in [`DOCS/INPROGRESS/`](../INPROGRESS) with concise details of what was done.
 - No untracked changes remain.
 
 ---

--- a/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
+++ b/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
@@ -2,8 +2,7 @@
 
 ## 🎯 Objective
 
-Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a
-context stack so downstream consumers (UI, CLI, validation) can react incrementally.
+Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a context stack so downstream consumers (UI, CLI, validation) can react incrementally.
 
 ## 🧩 Context
 
@@ -13,24 +12,23 @@ context stack so downstream consumers (UI, CLI, validation) can react incrementa
 
 ## ✅ Success Criteria
 
-- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per
-  specification.
+- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per specification.
+
 - Event stream maintains parent/child context via explicit stack without recursion depth issues.
-- Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than
-  crashing.
+- Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than crashing.
+
 - XCTest coverage proves deterministic event ordering and error handling across nominal and malformed inputs.
 
 ## 🔧 Implementation Notes
 
 - Use `RandomAccessReader` and `BoxHeaderDecoder` from B1/B2 as the foundation for reading headers and payload ranges.
-- Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure
-  thread safety with Swift concurrency primitives.
-- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload
-  boundaries.
-- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when
-  possible.
-- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing
-  test utilities.
+- Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure thread safety with Swift concurrency primitives.
+
+- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload boundaries.
+
+- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when possible.
+
+- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing test utilities.
 
 ## 🧠 Source References
 

--- a/DOCS/INPROGRESS/F1_Test_Fixtures.md
+++ b/DOCS/INPROGRESS/F1_Test_Fixtures.md
@@ -2,38 +2,36 @@
 
 ## 🎯 Objective
 
-Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed
-structures so the parser, validators, and exporters can be regression-tested automatically.
+Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed structures so the parser, validators, and exporters can be regression-tested automatically.
 
 ## 🧩 Context
 
-- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream
-  modules have reliable coverage of positive and negative cases.
-- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets
-  and licensing checks required before implementation.
-- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate
-  boundary conditions noted in the technical specification.
+- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream modules have reliable coverage of positive and negative cases.
+
+- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets and licensing checks required before implementation.
+
+- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate boundary conditions noted in the technical specification.
 
 ## ✅ Success Criteria
 
-- Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`,
-  and intentionally malformed headers.
-- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored
-  alongside the files for automated validation.
-- `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes
-  for both success and failure cases.
+- Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`, and intentionally malformed headers.
+
+- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored alongside the files for automated validation.
+
+- `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes for both success and failure cases.
+
 - Documentation explains sourcing/licensing for every file and the process to refresh or regenerate fixtures.
 
 ## 🔧 Implementation Notes
 
-- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative
-  files when licensing permits.
-- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in
-  Python as outlined in the AI Source Guide toolchain.
-- Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and
-  detect drift.
-- Define helper utilities (e.g., `FixtureCatalog`) that expose fixture metadata to tests and future benchmarks (F2)
-  without hard-coding paths.
+- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative files when licensing permits.
+
+- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in Python as outlined in the AI Source Guide toolchain.
+
+- Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and detect drift.
+
+- Define helper utilities (e.g., `FixtureCatalog`) that expose fixture metadata to tests and future benchmarks (F2) without hard-coding paths.
+
 - Anticipate reuse by CLI/UI teams by documenting fixture semantics in DocC or Guides for cross-team visibility.
 
 ## 🧠 Source References

--- a/DOCS/RULES/02_TDD_XP_Workflow.md
+++ b/DOCS/RULES/02_TDD_XP_Workflow.md
@@ -2,30 +2,22 @@
 
 ## Mission Statement
 
-You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is
-to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest
-architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
+You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
 
 ## Guiding Principles
 
-- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components
-  only when driven by failing tests at the current level.
-- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build,
-  tests, and deployment pipeline passing.
-- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are
-  acceptable only as placeholders that immediately fail and motivate implementation.
-- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify
-  design while keeping feedback loops tight.
-- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest
-  iterations.
+- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components only when driven by failing tests at the current level.
+- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build, tests, and deployment pipeline passing.
+- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are acceptable only as placeholders that immediately fail and motivate implementation.
+- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify design while keeping feedback loops tight.
+- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest iterations.
 
 ## Phase Overview
 
 1. **Initialize the Delivery Skeleton**
    - Create repository structure, build configuration, package metadata, and dependency management files.
    - Add continuous integration workflow (e.g., GitHub Actions) that runs the build, static checks, and the test suite.
-   - Configure automated release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes), even
-     if artifacts are placeholders.
+   - Configure release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes) even if artifacts are placeholders.
    - Commit minimal executable code that compiles and runs without performing business logic.
 
 1. **Author High-Level Acceptance Tests**
@@ -34,13 +26,10 @@ architectural concerns toward the smallest implementation details. Maintain cont
    - Acceptance tests should currently fail, documenting the desired capabilities before implementation.
 
 1. **Drive Implementation Outside-In**
-   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing
-     deeper collaborators.
-   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to
-     describe the required collaboration.
+   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing deeper collaborators.
+   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to describe the required collaboration.
    - Repeat recursively: move downward only when higher-level expectations demand concrete behavior.
-   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing
-     tests.
+   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing tests.
 
 1. **Refinement and Refactoring Cycle**
    - After each green build, refactor to remove duplication, clarify intent, and improve design.
@@ -67,7 +56,6 @@ architectural concerns toward the smallest implementation details. Maintain cont
 
 - Maintain a living architecture README that mirrors the current system boundaries.
 - For each iteration, record:
-
   - The acceptance test scenario addressed.
   - Newly introduced components or collaborators.
   - Refactorings performed and their rationale.
@@ -76,8 +64,7 @@ architectural concerns toward the smallest implementation details. Maintain cont
 
 ## Communication and Collaboration Norms
 
-- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid
-  asynchronous collaborators.
+- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid asynchronous collaborators.
 - Use feature flags or configuration toggles when partially implementing features to keep the main branch deployable.
 - Prefer small, frequent commits and pull requests aligned with single acceptance scenarios.
 

--- a/DOCS/RULES/03_Next_Task_Selection.md
+++ b/DOCS/RULES/03_Next_Task_Selection.md
@@ -2,29 +2,25 @@
 
 ## Purpose
 
-Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master
-PRD and execution guides.
+Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master PRD and execution guides.
 
 ## Required Inputs
 
-- `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for the authoritative task list, priorities, and
-  dependencies.
+- `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for the task list, priorities, and dependencies.
 - `DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md` to confirm scope and acceptance expectations.
 - The `DOCS/INPROGRESS/` directory (if present) to avoid duplicating tasks already underway.
 - Repository state indicators (tests, CI status) to verify prerequisite tasks are actually complete.
 
 ## Selection Steps
 
-1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a
-   document inside `DOCS/INPROGRESS/`.
-1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as
-   satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks)
-   or there is explicit documentation marking it complete.
-1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`).
-   When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
-1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps,
-   etc.). If blockers exist, return to step 3 with the next candidate.
-1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective,
-   scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
+1. **Enumerate candidates.** List open tasks from the Execution Workplan, excluding any already represented by a document inside `DOCS/INPROGRESS/`.
+
+1. **Filter by readiness.** Discard tasks whose listed dependencies are not yet satisfied. A dependency counts as satisfied only if its acceptance criteria are met in the codebase (e.g., `swift test` passes for build/setup tasks) or there is explicit documentation marking it complete.
+
+1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
+
+1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps, etc.). If blockers exist, return to step 3 with the next candidate.
+
+1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
 
 Following these steps keeps execution aligned with the strategic backlog while preventing conflicting workstreams.

--- a/DOCS/RULES/05_Markdown_Style.md
+++ b/DOCS/RULES/05_Markdown_Style.md
@@ -2,11 +2,13 @@
 
 ## 🧩 Purpose
 
-Uniform Markdown style for all project docs and strict post-generation validation. The goal is for every `DOCS/**` file to pass **markdownlint** checks.
+Uniform Markdown style for all project docs and strict post-generation validation. The goal is for every
+`DOCS/**` file to pass **markdownlint** checks.
 
 ## 🔧 Enforcement Scope
 
 Applies to all `.md` files in:
+
 - `DOCS/INPROGRESS/**`
 - `DOCS/COMMANDS/**`
 - `DOCS/RULES/**`
@@ -14,33 +16,25 @@ Applies to all `.md` files in:
 ## 📐 Style Rules (what the linter enforces)
 
 1. **Headings** are surrounded by blank lines above and below. (**MD022**)
-2. **Lists** (bulleted and ordered) are surrounded by blank lines above and below. (**MD032**)
-3. **Fenced code blocks**:
+1. **Lists** (bulleted and ordered) are surrounded by blank lines above and below. (**MD032**)
+1. **Fenced code blocks**:
    - Have a blank line before and after. (**MD031**)
    - Must specify a language after opening backticks (e.g., ```md, ```bash, ```json). (**MD040**)
-4. **Line length**:
-   - Max 120 characters for normal text and list bodies. (**MD013**)
-   - URLs and inline code may remain unwrapped (prefer keeping links intact).
-5. **Single top-level heading (H1)** per file when a title is present. (**MD025**)
-6. **Single trailing newline** at end of file—exactly one. (**MD047**)
-7. **Ordered lists** may consistently use the `1.` style for all items. (**MD029**)
+1. **Single top-level heading (H1)** per file when a title is present. (**MD025**)
+1. **Single trailing newline** at end of file—exactly one. (**MD047**)
+1. **Ordered lists** may consistently use the `1.` style for all items. (**MD029**)
+
+> ℹ️ While line length is no longer lint-enforced, prefer natural sentence wrapping for readability. Leave list items unwrapped when longer context improves clarity.
 
 ## ⚙️ Linter Configuration
 
-Create or update `.markdownlint.jsonc` at the repo root:
+Create or update `.markdownlint.jsonc` at the repo root (line-length rule disabled to avoid unnecessary wrapping of narrative and list content):
 
 ```jsonc
 {
   "default": true,
 
-  "MD013": {
-    "line_length": 120,
-    "heading_line_length": 120,
-    "code_blocks": false,
-    "tables": false,
-    "strict": false,
-    "ignore_urls": true
-  },
+  "MD013": false,
 
   "MD025": { "level": 1 },
   "MD040": true,
@@ -50,6 +44,7 @@ Create or update `.markdownlint.jsonc` at the repo root:
   "MD047": true,
   "MD029": { "style": "one" }
 }
+
 ```
 
 ## 🤖 Agent Behavior (required sequence)
@@ -64,29 +59,31 @@ Create or update `.markdownlint.jsonc` at the repo root:
    - Insert blank lines around lists.
    - Insert blank lines around fenced code blocks.
    - Ensure fenced code blocks specify a language (use `text` if unknown).
-   - Soft-wrap long lines at 120 characters for paragraphs and list bodies; do **not** break URLs/inline code/tables/quotes.
    - Normalize ordered lists to the `1.` style.
 
-2. **Run markdownlint locally** on the three DOCS paths.
+1. **Run markdownlint locally** on the three DOCS paths.
 
-3. **Validate result:**
+1. **Validate result:**
    - If any errors remain, attempt auto-fix again (up to 2 passes).
-   - If errors still remain, **reject** the change (or mark task as “blocked”) and record a failure report with rule+line numbers.
+   - If errors still remain, **reject** the change (or mark task as “blocked”) and record a failure report with
+     rule+line numbers.
+
    - If clean, proceed (commit/PR).
 
 ## 🧪 Local Check Command
 
 ```bash
 npx markdownlint-cli2 "DOCS/INPROGRESS/**/*.md" "DOCS/COMMANDS/**/*.md" "DOCS/RULES/**/*.md"
+
 ```
 
 ## 🛠 Recommended Auto-fix Script (reference)
 
 Call an idempotent fixer before lint:
+
 - Normalize trailing newline (MD047)
 - Add blank lines for headings/lists/fences (MD022/MD032/MD031)
 - Add language for code fences (MD040)
-- Wrap long lines to 120, ignoring URLs/inline code/tables/quotes (MD013)
 - Use `1.` for ordered lists (MD029)
 
 *(If you already have a similar fixer, you can reuse it.)*
@@ -96,7 +93,6 @@ Call an idempotent fixer before lint:
 - All touched `.md` files comply with `.markdownlint.jsonc`.
 - `markdownlint-cli2` returns **0 errors** on the enforced paths.
 - PR includes a successful linter log.
-- If MD013 remains due to unavoidable long URLs/tables, provide a short justification or rephrase text accordingly.
 
 ## 🚦 Optional GitHub Actions Snippet
 
@@ -130,4 +126,5 @@ jobs:
       - name: Run markdownlint
         run: |
           markdownlint-cli2 "DOCS/INPROGRESS/**/*.md" "DOCS/COMMANDS/**/*.md" "DOCS/RULES/**/*.md"
+
 ```


### PR DESCRIPTION
## Summary
- Disable the markdownlint MD013 rule so list items are no longer forced to wrap at 120 characters.
- Update the markdown style guide to explain the change and encourage natural, readability-focused wrapping.
- Reflow command prompts, in-progress briefs, and workflow rules to use single-line list items that match the relaxed guidance.

## Testing
- `npx markdownlint-cli2 "DOCS/INPROGRESS/**/*.md" "DOCS/COMMANDS/**/*.md" "DOCS/RULES/**/*.md"` *(fails: npm registry access returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e25dedbe788321a1bea56fa5f23a1f