### PR TITLE
Keep B2+ async evaluation task active

### DIFF
--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -54,7 +54,8 @@ Read and apply the selection rules from [`DOCS/RULES/03_Next_Task_Selection.md`]
   DOCS/INPROGRESS/03_Implement_New_Feature.md
   ```
 
-- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and guides located in other DOCS subfolders.
+- Inside the new file, include a **lightweight PRD (Product Requirements Document)** derived from the main PRD and
+  guides located in other DOCS subfolders.
 
 ### Step 5. PRD Content Template
 

--- a/DOCS/INPROGRESS/B2_Plus_Streaming_Interface_Evaluation.md
+++ b/DOCS/INPROGRESS/B2_Plus_Streaming_Interface_Evaluation.md
@@ -1,0 +1,39 @@
+# B2+ — Async Streaming Interface Evaluation
+
+## 🎯 Objective
+
+Assess and specify the async streaming interface that ISOInspectorCore should expose so higher parser layers can request
+progressive reads and react to parse events without blocking, preparing the pipeline for UI and CLI consumers.
+
+## 🧩 Context
+
+- Task B2 follow-up identified the need to evaluate async streaming interfaces once higher parser layers depend on
+  progressive reads, signaling that the header decoder work unblocked this
+  investigation.【F:DOCS/TASK_ARCHIVE/02_B2_Box_Header_Decoder/B2_Box_Header_Decoder_Summary.md†L1-L14】
+- The master PRD defines ISOInspectorCore as an async streaming parser that must deliver low-latency events to
+  downstream experiences, framing the interface
+  expectations.【F:DOCS/AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md†L1-L18】
+- The technical specification describes the parse pipeline emitting events over `AsyncStream`/Combine to consumers, indicating current architectural preferences to validate against during the evaluation.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L40】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L41-L74】
+
+## ✅ Success Criteria
+
+- Document a recommended async interface shape (e.g., `AsyncSequence`, `AsyncThrowingStream`, Combine publisher) with rationale covering concurrency guarantees, backpressure, and compatibility with SwiftUI/CLI consumers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L40】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L41-L74】
+- Provide a lightweight prototype or pseudocode demonstrating the interface integration with the existing `ParsePipeline` so it can emit ordered events that uphold PRD latency goals.【F:DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md†L1-L25】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L16-L23】
+- Capture consumer requirements (UI tree updates, CLI streaming) and note any additional dependencies or research items,
+  ensuring no unresolved blockers remain before implementation
+  proceeds.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L40】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L75-L106】
+
+## 🔧 Implementation Notes
+
+- Review existing parser prototypes (B3 task notes) to understand current event emission mechanics and ensure the chosen
+  interface aligns with the context stack strategy.【F:DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md†L1-L28】
+- Compare `AsyncStream` and Combine-based exposure, considering ergonomics for SwiftUI `ObservableObject` stores and CLI async/await consumption paths outlined in the technical spec.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L40】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L75-L106】
+- Identify any fixture or benchmarking needs (e.g., large `mdat` cases) to validate throughput once the interface lands, coordinating with F1 fixture development for representative samples.【F:DOCS/INPROGRESS/F1_Test_Fixtures.md†L1-L33】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L45-L52】
+
+## 🧠 Source References
+
+- [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [`DOCS/RULES`](../RULES)
+- [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)

--- a/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
+++ b/DOCS/INPROGRESS/B3_Streaming_Parse_Pipeline.md
@@ -2,7 +2,8 @@
 
 ## 🎯 Objective
 
-Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a context stack so downstream consumers (UI, CLI, validation) can react incrementally.
+Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits typed parse events, and maintains a
+context stack so downstream consumers (UI, CLI, validation) can react incrementally.
 
 ## 🧩 Context
 
@@ -12,7 +13,8 @@ Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits 
 
 ## ✅ Success Criteria
 
-- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per specification.
+- Parsing sample fixtures yields ordered parse events containing headers, offsets, and context metadata per
+  specification.
 
 - Event stream maintains parent/child context via explicit stack without recursion depth issues.
 - Pipeline handles container traversal, `size==0/1`, and malformed structures by emitting validation hooks rather than crashing.
@@ -24,11 +26,14 @@ Implement the streaming parse pipeline that reads MP4 boxes sequentially, emits 
 - Use `RandomAccessReader` and `BoxHeaderDecoder` from B1/B2 as the foundation for reading headers and payload ranges.
 - Define `ParsePipeline` (or similar) that produces `AsyncStream<ParseEvent>` or Combine publisher for consumers; ensure thread safety with Swift concurrency primitives.
 
-- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload boundaries.
+- Maintain an explicit context stack/iterator to traverse container boxes without recursion, enforcing declared payload
+  boundaries.
 
-- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when possible.
+- Integrate validation hooks for VR-001/VR-002, capturing issues in emitted events but allowing parsing to continue when
+  possible.
 
-- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing test utilities.
+- Provide smoke fixtures (small MP4 samples, malformed headers) to validate pipeline behavior; reuse or extend existing
+  test utilities.
 
 ## 🧠 Source References
 

--- a/DOCS/INPROGRESS/F1_Test_Fixtures.md
+++ b/DOCS/INPROGRESS/F1_Test_Fixtures.md
@@ -2,21 +2,26 @@
 
 ## 🎯 Objective
 
-Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed structures so the parser, validators, and exporters can be regression-tested automatically.
+Produce a curated collection of MP4/MOV sample files and supporting metadata that exercises nominal and malformed
+structures so the parser, validators, and exporters can be regression-tested automatically.
 
 ## 🧩 Context
 
-- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream modules have reliable coverage of positive and negative cases.
+- Execution Workplan task F1 prioritizes fixture development after B2 so the streaming pipeline (B3) and downstream
+  modules have reliable coverage of positive and negative cases.
 
-- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets and licensing checks required before implementation.
+- The Research Gaps log highlights R2 (Fixture Acquisition) as a prerequisite investigation, pointing to open datasets
+  and licensing checks required before implementation.
 
-- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate boundary conditions noted in the technical specification.
+- Phase B components already in place (chunked reader and box header decoder) depend on realistic payloads to validate
+  boundary conditions noted in the technical specification.
 
 ## ✅ Success Criteria
 
 - Fixture corpus includes at least: standard MP4, fragmented MP4, MOV variant, DASH init/media segments, large `mdat`, and intentionally malformed headers.
 
-- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored alongside the files for automated validation.
+- Each fixture ships with machine-readable metadata (box inventory, expected warnings/errors, licensing notes) stored
+  alongside the files for automated validation.
 
 - `swift test` suites load fixtures without exceeding memory/time budgets and assert expected parse/validation outcomes for both success and failure cases.
 
@@ -24,9 +29,11 @@ Produce a curated collection of MP4/MOV sample files and supporting metadata tha
 
 ## 🔧 Implementation Notes
 
-- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative files when licensing permits.
+- Collaborate with research outcomes from R2 to obtain legally distributable samples; prefer small but representative
+  files when licensing permits.
 
-- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in Python as outlined in the AI Source Guide toolchain.
+- Where real samples are unavailable, generate synthetic MP4 structures using Bento4 or FFmpeg tooling scripted in
+  Python as outlined in the AI Source Guide toolchain.
 
 - Store fixtures under `Tests/ISOInspectorKitTests/Fixtures/` with checksum tracking so CI can verify integrity and detect drift.
 

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,5 +1,5 @@
 # Next Tasks
 
-- [ ] B2+: Evaluate exposing async streaming interfaces once higher parser layers require progressive reads.
+- [ ] B2+: Evaluate exposing async streaming interfaces once higher parser layers require progressive reads. → Documented in `B2_Plus_Streaming_Interface_Evaluation.md`.
 
 Carried forward from B2_Box_Header_Decoder_Summary.md.

--- a/DOCS/RULES/02_TDD_XP_Workflow.md
+++ b/DOCS/RULES/02_TDD_XP_Workflow.md
@@ -2,22 +2,30 @@
 
 ## Mission Statement
 
-You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
+You are an autonomous engineering agent practicing Extreme Programming with full test-driven development. Your task is
+to grow the codebase from an initially empty scaffold to a production-ready system by iterating from the largest
+architectural concerns toward the smallest implementation details. Maintain continuous delivery readiness at all times.
 
 ## Guiding Principles
 
-- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components only when driven by failing tests at the current level.
-- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build, tests, and deployment pipeline passing.
-- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are acceptable only as placeholders that immediately fail and motivate implementation.
-- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify design while keeping feedback loops tight.
-- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest iterations.
+- **Outside-In Evolution:** Always start with the highest-level system behavior and refine toward lower-level components
+  only when driven by failing tests at the current level.
+- **Always Green Main Branch:** Ensure the default branch can be released at any time. Every commit must keep the build,
+  tests, and deployment pipeline passing.
+- **Test-First Mindset:** Do not write production code without a preceding failing test. Empty or pending tests are
+  acceptable only as placeholders that immediately fail and motivate implementation.
+- **Incremental Learning:** Treat each iteration as an opportunity to refine architecture, improve clarity, and simplify
+  design while keeping feedback loops tight.
+- **Automated Delivery:** Maintain automated build, test, artifact publishing, and release workflows from the earliest
+  iterations.
 
 ## Phase Overview
 
 1. **Initialize the Delivery Skeleton**
    - Create repository structure, build configuration, package metadata, and dependency management files.
    - Add continuous integration workflow (e.g., GitHub Actions) that runs the build, static checks, and the test suite.
-   - Configure release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes) even if artifacts are placeholders.
+   - Configure release tasks (e.g., packaging binaries, attaching artifacts, publishing release notes) even if artifacts
+     are placeholders.
    - Commit minimal executable code that compiles and runs without performing business logic.
 
 1. **Author High-Level Acceptance Tests**
@@ -26,10 +34,13 @@ You are an autonomous engineering agent practicing Extreme Programming with full
    - Acceptance tests should currently fail, documenting the desired capabilities before implementation.
 
 1. **Drive Implementation Outside-In**
-   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing deeper collaborators.
-   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to describe the required collaboration.
+   - Choose one failing acceptance test and implement just enough high-level scaffolding to make it pass, stubbing
+     deeper collaborators.
+   - When a stub prevents progress, write a new failing test at the next layer (e.g., integration or component test) to
+     describe the required collaboration.
    - Repeat recursively: move downward only when higher-level expectations demand concrete behavior.
-   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing tests.
+   - Keep production code minimal, duplicating logic only when necessary until refactoring is justified by passing
+     tests.
 
 1. **Refinement and Refactoring Cycle**
    - After each green build, refactor to remove duplication, clarify intent, and improve design.
@@ -39,7 +50,9 @@ You are an autonomous engineering agent practicing Extreme Programming with full
 1. **Deployment and Release Readiness**
    - Ensure CI pipelines produce deployable artifacts on every run.
    - Maintain versioning and changelog automation so that each merged change can be released without manual
+
      intervention.
+
    - Periodically execute a dry-run deployment to validate scripts and infrastructure.
 
 ## Iteration Template
@@ -64,7 +77,8 @@ You are an autonomous engineering agent practicing Extreme Programming with full
 
 ## Communication and Collaboration Norms
 
-- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid asynchronous collaborators.
+- Pairing and mobbing are encouraged; when operating solo, document rationale for significant decisions to aid
+  asynchronous collaborators.
 - Use feature flags or configuration toggles when partially implementing features to keep the main branch deployable.
 - Prefer small, frequent commits and pull requests aligned with single acceptance scenarios.
 

--- a/DOCS/RULES/03_Next_Task_Selection.md
+++ b/DOCS/RULES/03_Next_Task_Selection.md
@@ -2,7 +2,8 @@
 
 ## Purpose
 
-Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master PRD and execution guides.
+Ensure each new work item advances the product backlog in a controlled, dependency-aware order aligned with the master
+PRD and execution guides.
 
 ## Required Inputs
 
@@ -19,7 +20,8 @@ Ensure each new work item advances the product backlog in a controlled, dependen
 
 1. **Prioritize.** From the remaining tasks, choose the one with the highest priority value (`High` > `Medium` > `Low`). When priorities match, prefer the task from the earliest phase (alphabetical) and then the lowest task ID number.
 
-1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps, etc.). If blockers exist, return to step 3 with the next candidate.
+1. **Sanity check.** Confirm no blocking risks are noted in the PRD/Guides for the candidate (licensing, tooling gaps,
+   etc.). If blockers exist, return to step 3 with the next candidate.
 
 1. **Record the decision.** Create/update an `INPROGRESS` document named after the chosen task. Summarize objective, scope, dependencies, and immediate next steps in light PRD format so future agents understand the current focus.
 

--- a/DOCS/RULES/05_Markdown_Style.md
+++ b/DOCS/RULES/05_Markdown_Style.md
@@ -66,6 +66,7 @@ Create or update `.markdownlint.jsonc` at the repo root (line-length rule disabl
 1. **Validate result:**
    - If any errors remain, attempt auto-fix again (up to 2 passes).
    - If errors still remain, **reject** the change (or mark task as “blocked”) and record a failure report with
+
      rule+line numbers.
 
    - If clean, proceed (commit/PR).


### PR DESCRIPTION
## Summary
- mark the B2+ async streaming evaluation item as still in progress on the next tasks tracker
- format the updated documentation with the repository fix_markdown script to satisfy linting rules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e276cb98cc8321a1aca26dc35d1473