### PR TITLE
Add markdown validation reminder to command docs

### DIFF
--- a/DOCS/COMMANDS/ARCHIVE.md
+++ b/DOCS/COMMANDS/ARCHIVE.md
@@ -142,3 +142,5 @@ DOCS/
 ---
 
 ## END OF SYSTEM PROMPT
+
+At the end of working validate new files Markdown with Python script at the path `scripts/fix_markdown.py` before push to remote.

--- a/DOCS/COMMANDS/SELECT_NEXT.md
+++ b/DOCS/COMMANDS/SELECT_NEXT.md
@@ -144,3 +144,5 @@ DOCS/
 ---
 
 ## END OF SYSTEM PROMPT
+
+At the end of working validate new files Markdown with Python script at the path `scripts/fix_markdown.py` before push to remote.

--- a/DOCS/COMMANDS/START.md
+++ b/DOCS/COMMANDS/START.md
@@ -149,3 +149,5 @@ DOCS/
 ---
 
 ## END OF SYSTEM PROMPT
+
+At the end of working validate new files Markdown with Python script at the path `scripts/fix_markdown.py` before push to remote.


### PR DESCRIPTION
## Summary
- append a reminder to each command workflow document in `DOCS/COMMANDS`
- instruct contributors to run `scripts/fix_markdown.py` before pushing new Markdown files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e367a7fc788321bffd9ec102211468