### PR TITLE
Wire live parse pipeline to streaming walker

### DIFF
--- a/DOCS/INPROGRESS/05_B3_Puzzle1_ParsePipeline_Live_Integration.md
+++ b/DOCS/INPROGRESS/05_B3_Puzzle1_ParsePipeline_Live_Integration.md
@@ -7,30 +7,43 @@ Implement the production `ParsePipeline.live()` builder so it drives the concret
 ## 🧩 Context
 
 - Puzzle #1 is the remaining open item from the archived B3 streaming work notes and is also called out in the active
+
   next-task queue, keeping the parser backlog aligned with the
-  workplan.【F:DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/next_tasks.md†L1-L4】【F:DOCS/INPROGRESS/next_tasks.md†L1-L4】
+
+workplan.【F:DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/next_tasks.md†L1-L4】【F:DOCS/INPROGRESS/next_tasks.md†L1-L4】
+
 - Phase B of the execution workplan marks B1 and B2 as complete, leaving B3 (streaming parse pipeline) as the
+
   highest-priority dependency for UI/CLI features that consume live
   events.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L27】
+
 - The PRD and technical specification require the pipeline to traverse MP4 boxes in document order, maintain a context stack, and surface validation hooks over an `AsyncStream`, so the integration must respect those contracts.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L12-L33】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L50-L58】
 
 ## ✅ Success Criteria
 
 - `ParsePipeline.live()` returns an `AsyncThrowingStream` that iterates using the streaming walker, yielding `willStartBox` and `didFinishBox` events with accurate offsets for nested containers and `mdat` skips.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L37-L132】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L28-L33】
 - Integration tests cover at least one nested fixture and a large-size box to confirm ordering, depth accounting, and
+
   error propagation from the walker through the stream
   continuation.【F:DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/B3_ParsePipeline_Live_Streaming.md†L5-L22】
+
 - Cancellation and failure states from the walker terminate the stream cleanly, matching the concurrency guarantees
+
   promised in the technical spec and workplan acceptance
-  criteria.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L37-L132】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L27】
+
+criteria.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L37-L132】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L27】
+
 - Existing automated tests (`swift test`) continue to pass after the integration, ensuring no regressions in prior B1/B2 functionality.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L27】
 
 ## 🔧 Implementation Notes
 
 - Leverage the existing `RandomAccessReader` protocol and helpers for header reads; ensure walker logic uses bounded ranges when decoding sizes and UUID payloads.【F:Sources/ISOInspectorKit/IO/RandomAccessReader.swift†L3-L55】【F:Sources/ISOInspectorKit/ISO/BoxHeaderDecoder.swift†L1-L140】
 - Maintain an explicit traversal stack mirroring the archived B3 solution so each container yields paired start/finish
+
   events without recursion depth
-  issues.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L56-L121】【F:DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/B3_ParsePipeline_Live_Streaming.md†L5-L22】
+
+issues.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L56-L121】【F:DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/B3_ParsePipeline_Live_Streaming.md†L5-L22】
+
 - Skip `mdat` payload bodies by advancing the cursor to the payload end while still emitting metadata events; this satisfies the streaming performance expectations from the PRD backlog.【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L75-L86】【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L94-L121】
 - Surface walker errors (header decoding, boundary violations) by finishing the stream with a thrown error, and wire cancellation via `Task.checkCancellation()` to honor consumer backpressure.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L37-L120】
 

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,18 @@
+# Summary of Work
+
+## Completed Tasks
+
+- **Puzzle #1 — Wire `ParsePipeline.live()` to the streaming walker:** Implemented the concrete `StreamingBoxWalker`, refactored `ParsePipeline.live()` to drive it, and added dedicated unit tests covering nested traversal, large boxes, error propagation, and cancellation semantics.
+
+## Test Evidence
+
+- `swift test`
+
+## Documentation Updates
+
+- Marked Puzzle #1 as complete in `DOCS/INPROGRESS/next_tasks.md` and the archived checklist.
+
+## Follow-Up Notes
+
+- Proceed to downstream parser tasks (e.g., B4 catalog integration) now that live streaming events are emitted from real
+  walker logic.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,3 +1,3 @@
 # Next Tasks
 
-- [ ] Complete Puzzle #1 by wiring `ParsePipeline.live()` to the real streaming walker so the async pipeline runs against concrete parsing logic.
+- [x] Complete Puzzle #1 by wiring `ParsePipeline.live()` to the real streaming walker so the async pipeline runs against concrete parsing logic.

--- a/DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/next_tasks.md
+++ b/DOCS/TASK_ARCHIVE/04_B3_ParsePipeline_Live_Streaming/next_tasks.md
@@ -1,3 +1,3 @@
 # Next Tasks
 
-- [ ] Complete Puzzle #1 by wiring `ParsePipeline.live()` to the real streaming walker so the async pipeline runs against concrete parsing logic.
+- [x] Complete Puzzle #1 by wiring `ParsePipeline.live()` to the real streaming walker so the async pipeline runs against concrete parsing logic.

--- a/Sources/ISOInspectorKit/ISO/ParsePipeline.swift
+++ b/Sources/ISOInspectorKit/ISO/ParsePipeline.swift
@@ -39,8 +39,18 @@ public extension ParsePipeline {
         ParsePipeline(buildStream: { reader in
             AsyncThrowingStream { continuation in
                 let task = Task {
+                    let walker = StreamingBoxWalker()
                     do {
-                        try process(reader: reader, continuation: continuation)
+                        try walker.walk(
+                            reader: reader,
+                            cancellationCheck: { try Task.checkCancellation() },
+                            onEvent: { event in
+                                continuation.yield(event)
+                            },
+                            onFinish: {
+                                continuation.finish()
+                            }
+                        )
                     } catch {
                         continuation.finish(throwing: error)
                     }
@@ -52,81 +62,4 @@ public extension ParsePipeline {
             }
         })
     }
-
-    private struct Frame {
-        let header: BoxHeader?
-        let range: Range<Int64>
-        var cursor: Int64
-        let depth: Int
-        let shouldParseChildren: Bool
-    }
-
-    private static func process(
-        reader: RandomAccessReader,
-        continuation: AsyncThrowingStream<ParseEvent, Error>.Continuation
-    ) throws {
-        var stack: [Frame] = [Frame(
-            header: nil,
-            range: Int64(0)..<reader.length,
-            cursor: Int64(0),
-            depth: -1,
-            shouldParseChildren: true
-        )]
-
-        while let frame = stack.last {
-            try Task.checkCancellation()
-
-            if !frame.shouldParseChildren || frame.cursor >= frame.range.upperBound {
-                let finished = stack.removeLast()
-                if let header = finished.header {
-                    let event = ParseEvent(
-                        kind: .didFinishBox(header: header, depth: finished.depth),
-                        offset: header.endOffset
-                    )
-                    continuation.yield(event)
-                    continue
-                } else {
-                    continuation.finish()
-                    return
-                }
-            }
-
-            var parent = frame
-            let offset = parent.cursor
-            let header = try BoxHeaderDecoder.readHeader(
-                from: reader,
-                at: offset,
-                inParentRange: parent.range
-            )
-            parent.cursor = header.range.upperBound
-            stack[stack.count - 1] = parent
-
-            let depth = parent.depth + 1
-            continuation.yield(
-                ParseEvent(
-                    kind: .willStartBox(header: header, depth: depth),
-                    offset: header.startOffset
-                )
-            )
-
-            let payloadRange = header.payloadRange
-            let shouldParseChildren = isContainer(header: header) && payloadRange.lowerBound < payloadRange.upperBound
-            stack.append(Frame(
-                header: header,
-                range: payloadRange,
-                cursor: payloadRange.lowerBound,
-                depth: depth,
-                shouldParseChildren: shouldParseChildren
-            ))
-        }
-    }
-
-    private static func isContainer(header: BoxHeader) -> Bool {
-        containerTypes.contains(header.type.rawValue)
-    }
-
-    private static let containerTypes: Set<String> = [
-        "moov", "trak", "mdia", "minf", "dinf", "stbl", "edts", "mvex", "moof", "traf",
-        "mfra", "tref", "udta", "strk", "strd", "sinf", "schi", "stsd", "meta", "ilst"
-    ]
 }

--- a/Sources/ISOInspectorKit/ISO/StreamingBoxWalker.swift
+++ b/Sources/ISOInspectorKit/ISO/StreamingBoxWalker.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+public struct StreamingBoxWalker: Sendable {
+    public typealias CancellationCheck = () throws -> Void
+    public typealias EventHandler = (ParseEvent) -> Void
+    public typealias FinishHandler = () -> Void
+
+    public init() {}
+
+    public func walk(
+        reader: RandomAccessReader,
+        cancellationCheck: CancellationCheck,
+        onEvent: EventHandler,
+        onFinish: FinishHandler
+    ) throws {
+        var stack: [Frame] = [Frame(
+            header: nil,
+            range: Int64(0)..<reader.length,
+            cursor: Int64(0),
+            depth: -1,
+            shouldParseChildren: true
+        )]
+
+        while let frame = stack.last {
+            try cancellationCheck()
+
+            if !frame.shouldParseChildren || frame.cursor >= frame.range.upperBound {
+                let finished = stack.removeLast()
+                if let header = finished.header {
+                    let event = ParseEvent(
+                        kind: .didFinishBox(header: header, depth: finished.depth),
+                        offset: header.endOffset
+                    )
+                    onEvent(event)
+                    continue
+                } else {
+                    onFinish()
+                    return
+                }
+            }
+
+            var parent = frame
+            let offset = parent.cursor
+            let header = try BoxHeaderDecoder.readHeader(
+                from: reader,
+                at: offset,
+                inParentRange: parent.range
+            )
+            parent.cursor = header.range.upperBound
+            stack[stack.count - 1] = parent
+
+            let depth = parent.depth + 1
+            let startEvent = ParseEvent(
+                kind: .willStartBox(header: header, depth: depth),
+                offset: header.startOffset
+            )
+            onEvent(startEvent)
+
+            let payloadRange = header.payloadRange
+            let shouldParseChildren = Self.shouldParseChildren(for: header, payloadRange: payloadRange)
+            stack.append(Frame(
+                header: header,
+                range: payloadRange,
+                cursor: payloadRange.lowerBound,
+                depth: depth,
+                shouldParseChildren: shouldParseChildren
+            ))
+        }
+    }
+}
+
+private extension StreamingBoxWalker {
+    struct Frame {
+        let header: BoxHeader?
+        let range: Range<Int64>
+        var cursor: Int64
+        let depth: Int
+        let shouldParseChildren: Bool
+    }
+
+    static func shouldParseChildren(for header: BoxHeader, payloadRange: Range<Int64>) -> Bool {
+        guard payloadRange.lowerBound < payloadRange.upperBound else {
+            return false
+        }
+        return containerTypes.contains(header.type.rawValue)
+    }
+
+    static let containerTypes: Set<String> = [
+        "moov", "trak", "mdia", "minf", "dinf", "stbl", "edts", "mvex", "moof", "traf",
+        "mfra", "tref", "udta", "strk", "strd", "sinf", "schi", "stsd", "meta", "ilst"
+    ]
+}

--- a/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
+++ b/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class StreamingBoxWalkerTests: XCTestCase {
+    func testWalkerEmitsEventsForNestedBoxes() throws {
+        let tkhd = makeBox(type: "tkhd", payload: Data())
+        let trak = makeBox(type: "trak", payload: tkhd)
+        let moov = makeBox(type: "moov", payload: trak)
+        let ftypPayload = Data(repeating: 0, count: 16)
+        let ftyp = makeBox(type: "ftyp", payload: ftypPayload)
+        let data = ftyp + moov
+
+        let reader = InMemoryRandomAccessReader(data: data)
+        let walker = StreamingBoxWalker()
+
+        var events: [ParseEvent] = []
+        var finished = false
+        try walker.walk(
+            reader: reader,
+            cancellationCheck: {},
+            onEvent: { event in
+                events.append(event)
+            },
+            onFinish: {
+                finished = true
+            }
+        )
+
+        XCTAssertTrue(finished)
+        XCTAssertEqual(events.count, 8)
+        try assertEvent(events[0], kind: .willStart, type: "ftyp", depth: 0, offset: 0)
+        try assertEvent(events[1], kind: .didFinish, type: "ftyp", depth: 0, offset: Int64(ftyp.count))
+        try assertEvent(events[2], kind: .willStart, type: "moov", depth: 0, offset: Int64(ftyp.count))
+        try assertEvent(events[3], kind: .willStart, type: "trak", depth: 1, offset: Int64(ftyp.count + 8))
+        try assertEvent(events[4], kind: .willStart, type: "tkhd", depth: 2, offset: Int64(ftyp.count + 16))
+        try assertEvent(events[5], kind: .didFinish, type: "tkhd", depth: 2, offset: Int64(ftyp.count + moov.count))
+        try assertEvent(events[6], kind: .didFinish, type: "trak", depth: 1, offset: Int64(ftyp.count + moov.count))
+        try assertEvent(events[7], kind: .didFinish, type: "moov", depth: 0, offset: Int64(ftyp.count + moov.count))
+    }
+
+    func testWalkerHandlesLargeSizeBoxes() throws {
+        let payload = Data(repeating: 0xFF, count: 12)
+        let largeBox = makeBox(type: "mdat", payload: payload, useLargeSize: true)
+        let reader = InMemoryRandomAccessReader(data: largeBox)
+        let walker = StreamingBoxWalker()
+
+        var events: [ParseEvent] = []
+        var finished = false
+        try walker.walk(
+            reader: reader,
+            cancellationCheck: {},
+            onEvent: { event in
+                events.append(event)
+            },
+            onFinish: {
+                finished = true
+            }
+        )
+
+        XCTAssertTrue(finished)
+        XCTAssertEqual(events.count, 2)
+        try assertEvent(events[0], kind: .willStart, type: "mdat", depth: 0, offset: 0)
+        try assertEvent(events[1], kind: .didFinish, type: "mdat", depth: 0, offset: Int64(largeBox.count))
+    }
+
+    func testWalkerPropagatesHeaderErrors() {
+        var corrupted = Data()
+        corrupted.append(contentsOf: UInt32(24).bigEndianBytes)
+        corrupted.append(contentsOf: "ftyp".utf8)
+        corrupted.append(Data(repeating: 0, count: 4))
+        let reader = InMemoryRandomAccessReader(data: corrupted)
+        let walker = StreamingBoxWalker()
+
+        XCTAssertThrowsError(
+            try walker.walk(
+                reader: reader,
+                cancellationCheck: {},
+                onEvent: { _ in },
+                onFinish: {}
+            )
+        ) { error in
+            XCTAssertTrue(error is BoxHeaderDecodingError)
+        }
+    }
+
+    func testWalkerStopsWhenCancellationCheckThrows() {
+        let payload = Data(repeating: 0xAA, count: 8)
+        let free = makeBox(type: "free", payload: payload)
+        let data = free + free
+        let reader = InMemoryRandomAccessReader(data: data)
+        let walker = StreamingBoxWalker()
+
+        var shouldCancel = false
+        var events: [ParseEvent] = []
+        var finished = false
+
+        struct TestCancellationError: Error {}
+
+        XCTAssertThrowsError(
+            try walker.walk(
+                reader: reader,
+                cancellationCheck: {
+                    if shouldCancel {
+                        throw TestCancellationError()
+                    }
+                },
+                onEvent: { event in
+                    events.append(event)
+                    if events.count == 2 { // After first box start
+                        shouldCancel = true
+                    }
+                },
+                onFinish: {
+                    finished = true
+                }
+            )
+        ) { error in
+            XCTAssertTrue(error is TestCancellationError)
+        }
+
+        XCTAssertFalse(finished)
+        XCTAssertEqual(events.count, 2)
+    }
+
+    private enum EventKind {
+        case willStart
+        case didFinish
+    }
+
+    private func assertEvent(
+        _ event: ParseEvent,
+        kind expectedKind: EventKind,
+        type expectedType: String,
+        depth expectedDepth: Int,
+        offset expectedOffset: Int64
+    ) throws {
+        let type = try FourCharCode(expectedType)
+        switch (event.kind, expectedKind) {
+        case let (.willStartBox(header, depth), .willStart):
+            XCTAssertEqual(header.type, type)
+            XCTAssertEqual(depth, expectedDepth)
+            XCTAssertEqual(event.offset, expectedOffset)
+        case let (.didFinishBox(header, depth), .didFinish):
+            XCTAssertEqual(header.type, type)
+            XCTAssertEqual(depth, expectedDepth)
+            XCTAssertEqual(event.offset, expectedOffset)
+        default:
+            XCTFail("Unexpected event kind: \(event.kind)")
+        }
+    }
+
+    private func makeBox(type: String, payload: Data, useLargeSize: Bool = false) -> Data {
+        precondition(type.utf8.count == 4, "Box type must be four characters")
+        var data = Data()
+        let payloadCount = payload.count
+        if useLargeSize {
+            let headerSize = 16
+            let totalSize = headerSize + payloadCount
+            data.append(contentsOf: UInt32(1).bigEndianBytes)
+            data.append(contentsOf: type.utf8)
+            data.append(contentsOf: UInt64(totalSize).bigEndianBytes)
+        } else {
+            let totalSize = 8 + payloadCount
+            data.append(contentsOf: UInt32(totalSize).bigEndianBytes)
+            data.append(contentsOf: type.utf8)
+        }
+        data.append(payload)
+        return data
+    }
+}
+
+private extension FixedWidthInteger {
+    var bigEndianBytes: [UInt8] {
+        withUnsafeBytes(of: self.bigEndian, Array.init)
+    }
+}


### PR DESCRIPTION
## Summary
- add a `StreamingBoxWalker` that walks MP4 boxes from a `RandomAccessReader` and emits `ParseEvent`s
- refactor `ParsePipeline.live()` to drive the new walker and properly finish or error the async stream
- add focused unit tests for the walker and document the completed puzzle in the in-progress tracker

## Testing
- swift test
- python scripts/fix_markdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e368a5cd0c83218ce8d56a3124ed2f