### PR TITLE
Add R1 MP4RA catalog refresh task outline

### DIFF
--- a/DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md
+++ b/DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md
@@ -1,0 +1,43 @@
+# R1 — MP4RA Catalog Refresh Automation
+
+## 🎯 Objective
+
+Implement automation to refresh `MP4RABoxes.json` from the upstream MP4RA registry and publish a repeatable maintenance workflow for keeping the catalog current.【F:todo.md†L1-L4】
+
+## 🧩 Context
+
+- Research gap **R1 – MP4RA Synchronization** calls for a scripted process to fetch registered box metadata and defines
+  it as a high-priority follow-up to the catalog integration
+  work.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
+- Task B4 completed the initial MP4RA catalog integration and explicitly carried forward the need for refresh automation
+  and downstream consumers in the backlog summary.【F:DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md†L22-L33】
+- The technical specification mandates keeping the catalog synced with MP4RA updates via a dedicated fetch script,
+  reinforcing this task’s scope.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L101-L105】
+
+## ✅ Success Criteria
+
+- A scripted or documented automation path retrieves the latest MP4RA registry data (HTML, CSV, or JSON) and regenerates `MP4RABoxes.json` without manual editing.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
+- Running the automation updates metadata versioning markers (timestamp, source URL, or hash) and verifies schema
+  compatibility with existing catalog consumers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L101-L105】
+- A maintenance guide covers prerequisites, execution steps, validation checks, and contribution workflow updates so
+  other contributors can refresh the catalog
+  confidently.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L32-L40】
+
+## 🔧 Implementation Notes
+
+- Inspect MP4RA registry endpoints (HTML listings, CSV downloads, JSON feeds) and select a stable source for automation,
+  capturing fallbacks if the preferred format is
+  unavailable.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
+- Decide whether the automation lives as a Swift command, Python script, or documented manual recipe; align tooling with
+  existing repository scripting
+  conventions.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L32-L40】
+- Integrate validation hooks so stale or malformed catalog data surfaces warnings during tests or CI, preventing
+  regressions in downstream validation/reporting tasks.【F:DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md†L22-L33】
+
+## 🧠 Source References
+
+- [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [`DOCS/RULES`](../RULES)
+- [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -3,4 +3,5 @@
 - [ ] Implement automation for refreshing `MP4RABoxes.json` from the upstream registry and document the maintenance workflow (`@todo #2`).
 - [ ] Extend downstream validation and reporting to consume the enriched MP4RA metadata emitted by `ParsePipeline.live()`.
 - [ ] Outline the additional downstream parser follow-ups now unlocked by real-time streaming events (e.g., catalog
+
   integration test coverage and fallback handling).


### PR DESCRIPTION
## Summary
- add an in-progress task document describing the MP4RA catalog refresh automation effort
- normalize the next_tasks checklist formatting via the markdown fixer

## Testing
- python3 scripts/fix_markdown.py DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md

------
https://chatgpt.com/codex/tasks/task_e_68e42aabe9f483219744ec2c68bf0153