### PR TITLE
Preserve legacy MP4RA metadata while refreshing catalog

### DIFF
--- a/DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md
+++ b/DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md
@@ -5,13 +5,16 @@ This log enumerates knowledge gaps and research activities required to ensure co
 ## Open Research Tasks
 | Task ID | Topic | Objective | Priority | Effort (days) | Dependencies | Research Approach | Acceptance Criteria |
 |---------|-------|-----------|----------|---------------|--------------|-------------------|---------------------|
-| R1 | MP4RA Synchronization | Determine process to fetch and update MP4 registered box metadata automatically. | High | 1 | None | Review [MP4RA registry](https://mp4ra.org/registered-types/boxes), inspect available data formats (HTML, CSV, JSON), design scraper or API client. | Documented script plan specifying source URLs, parsing strategy, and update frequency. |
 | R2 | Fixture Acquisition | Identify representative MP4 samples covering standard, fragmented, and vendor-specific atoms. | High | 2 | None | Search open datasets (Apple sample media, DASH-IF) and internal archives; compile licensing notes. | Curated list of sample files with download links, sizes, and licensing status. |
 | R3 | Accessibility Guidelines | Validate VoiceOver and Dynamic Type best practices for complex SwiftUI trees. | Medium | 1.5 | None | Review Apple Accessibility Programming Guide; gather examples from existing open-source apps. | Checklist of UI compliance actions integrated into Phase C tasks. |
 | R4 | Large File Performance Benchmarks | Determine benchmarking methodology and tooling for 20 GB files on macOS CI. | Medium | 2 | B1 | Investigate file generation techniques (dd, custom generator), virtualization requirements, and instrumentation. | Benchmark protocol document describing test data creation, measurement steps, and resource constraints. |
 | R5 | Export Schema Standardization | Research industry-standard JSON schemas for MP4 inspection reports. | Medium | 1.5 | B6 | Survey existing tools (Bento4, ffprobe) for report formats; evaluate compatibility. | Proposal comparing schema options with recommendation and mapping to ISOInspector fields. |
 | R6 | Annotation Persistence Strategy | Evaluate CoreData vs. JSON for cross-platform annotation storage. | Low | 1 | C4 | Review storage requirements, conflict resolution needs, and iCloud sync options. | Decision record outlining chosen storage mechanism with rationale. |
 | R7 | CLI Distribution | Investigate best practices for distributing signed CLI binaries for macOS and Linux. | Low | 1.5 | D3 | Review notarization, Homebrew tap creation, and Linux package formats. | Distribution plan covering signing, packaging, and update strategy. |
+
+## Completed Research
+
+- **R1 — MP4RA Synchronization (2025-10-06):** Automated the MP4RA registry refresh via the new `MP4RACatalogRefresher` and `isoinspect mp4ra refresh` command, with workflow guidance captured in `Docs/Guides/MP4RARefreshGuide.md` and summary notes in `DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md`.
 
 ## Tracking & Reporting
 - Update this table as research completes or new gaps are discovered.

--- a/DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md
+++ b/DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md
@@ -7,31 +7,44 @@ Implement automation to refresh `MP4RABoxes.json` from the upstream MP4RA regist
 ## 🧩 Context
 
 - Research gap **R1 – MP4RA Synchronization** calls for a scripted process to fetch registered box metadata and defines
+
   it as a high-priority follow-up to the catalog integration
   work.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
+
 - Task B4 completed the initial MP4RA catalog integration and explicitly carried forward the need for refresh automation
+
   and downstream consumers in the backlog summary.【F:DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md†L22-L33】
+
 - The technical specification mandates keeping the catalog synced with MP4RA updates via a dedicated fetch script,
+
   reinforcing this task’s scope.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L101-L105】
 
 ## ✅ Success Criteria
 
 - A scripted or documented automation path retrieves the latest MP4RA registry data (HTML, CSV, or JSON) and regenerates `MP4RABoxes.json` without manual editing.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
 - Running the automation updates metadata versioning markers (timestamp, source URL, or hash) and verifies schema
+
   compatibility with existing catalog consumers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L101-L105】
+
 - A maintenance guide covers prerequisites, execution steps, validation checks, and contribution workflow updates so
+
   other contributors can refresh the catalog
   confidently.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L32-L40】
 
 ## 🔧 Implementation Notes
 
 - Inspect MP4RA registry endpoints (HTML listings, CSV downloads, JSON feeds) and select a stable source for automation,
+
   capturing fallbacks if the preferred format is
   unavailable.【F:DOCS/AI/ISOInspector_Execution_Guide/05_Research_Gaps.md†L5-L14】
+
 - Decide whether the automation lives as a Swift command, Python script, or documented manual recipe; align tooling with
+
   existing repository scripting
   conventions.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L32-L40】
+
 - Integrate validation hooks so stale or malformed catalog data surfaces warnings during tests or CI, preventing
+
   regressions in downstream validation/reporting tasks.【F:DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md†L22-L33】
 
 ## 🧠 Source References
@@ -41,3 +54,10 @@ Implement automation to refresh `MP4RABoxes.json` from the upstream MP4RA regist
 - [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [`DOCS/RULES`](../RULES)
 - [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)
+
+## ✅ Completion Notes — 2025-10-06
+
+- Added a reusable `MP4RACatalogRefresher` in `ISOInspectorKit` plus a new `isoinspect mp4ra refresh` CLI command to automate downloads from `https://mp4ra.org/api/boxes`.
+- Regenerated `Sources/ISOInspectorKit/Resources/MP4RABoxes.json` with 1,100+ entries and embedded metadata (`source`, `fetchedAt`, `recordCount`).
+- Documented the refresh workflow in `Docs/Guides/MP4RARefreshGuide.md` and marked Puzzle `@todo #2` complete in code and `todo.md`.
+- Updated research and archive tracking files to record the delivery of Research Task R1.

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,26 @@
+# Summary of Work — 2025-10-06
+
+## Completed Tasks
+
+- R1 — MP4RA Catalog Refresh Automation (`DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md`).
+
+## Implementation Highlights
+
+- Added `MP4RACatalogRefresher` and supporting HTTP data provider to `ISOInspectorKit`, including metadata-aware JSON generation and FourCC normalization.
+- Extended the `isoinspect` CLI with a new `mp4ra refresh` command backed by dependency-injectable environment hooks for testing.
+- Regenerated `MP4RABoxes.json` (1,167 entries) with embedded provenance metadata and updated `BoxCatalog` to remove the fulfilled puzzle reference.
+
+## Documentation & Tracking
+
+- Authored `Docs/Guides/MP4RARefreshGuide.md` describing the maintenance workflow.
+- Updated `todo.md`, `DOCS/INPROGRESS/next_tasks.md`, research gap logs, and task archive summaries to reflect completion of Puzzle `@todo #2` (Research Task R1).
+
+## Validation
+
+- `swift test`
+- `swift run isoinspect mp4ra refresh`
+
+## Pending Follow-Ups
+
+- Extend downstream validation/reporting to consume the enriched MP4RA metadata.
+- Outline additional parser follow-ups enabled by real-time streaming events (see `DOCS/INPROGRESS/next_tasks.md`).

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,6 +1,6 @@
 # Next Tasks
 
-- [ ] Implement automation for refreshing `MP4RABoxes.json` from the upstream registry and document the maintenance workflow (`@todo #2`).
+- [x] Implement automation for refreshing `MP4RABoxes.json` from the upstream registry and document the maintenance workflow (`@todo #2`).
 - [ ] Extend downstream validation and reporting to consume the enriched MP4RA metadata emitted by `ParsePipeline.live()`.
 - [ ] Outline the additional downstream parser follow-ups now unlocked by real-time streaming events (e.g., catalog
 

--- a/DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/Summary_of_Work.md
+++ b/DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/Summary_of_Work.md
@@ -17,5 +17,5 @@
 
 ## Follow-Ups
 
-- Implement automation for refreshing `MP4RABoxes.json` from the upstream registry and document the maintenance workflow (`@todo #2`).
+- ✅ Implement automation for refreshing `MP4RABoxes.json` from the upstream registry and document the maintenance workflow (`@todo #2`) via R1 (`DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md`).
 - Extend downstream validation and reporting to consume the enriched metadata (future task planning).

--- a/DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md
+++ b/DOCS/TASK_ARCHIVE/ARCHIVE_SUMMARY.md
@@ -29,4 +29,4 @@
 - **Archived files:** `B4_MP4RA_Metadata_Integration.md`, `Summary_of_Work.md`, and the prior `next_tasks.md` checklist captured during Task B4.
 - **Archived location:** `DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/`
 - **Highlights:** Records integration of the MP4RA-backed `BoxCatalog` into the streaming pipeline, inclusion of the bundled metadata fixture, and expanded diagnostics plus coverage for standard and UUID-based boxes.
-- **Next steps carried forward:** Track automation for refreshing `MP4RABoxes.json`, extend downstream validation/reporting that consumes enriched metadata, and outline the new parser follow-ups enabled by real-time streaming events.
+- **Next steps carried forward:** ✅ Automation for refreshing `MP4RABoxes.json` now ships via R1 (`DOCS/INPROGRESS/07_R1_MP4RA_Catalog_Refresh.md`). Continue extending downstream validation/reporting that consumes enriched metadata and outline the parser follow-ups enabled by real-time streaming events.

--- a/Docs/Guides/MP4RARefreshGuide.md
+++ b/Docs/Guides/MP4RARefreshGuide.md
@@ -1,0 +1,43 @@
+# MP4RA Catalog Refresh Guide
+
+This guide documents the repeatable workflow for updating `Sources/ISOInspectorKit/Resources/MP4RABoxes.json` from the official MP4RA registry.
+
+## Prerequisites
+
+- Active internet access (the registry is fetched from `https://mp4ra.org/api/boxes`).
+- Swift toolchain available locally (the project already uses Swift Package Manager).
+- Run commands from the repository root unless otherwise noted.
+
+## Refresh Workflow
+
+1. **Fetch the latest registry JSON and regenerate the bundled catalog.**
+
+   ```bash
+   swift run isoinspect mp4ra refresh
+   ```
+
+   - The command downloads the registry, normalizes MP4 box identifiers (including `$20`-encoded spaces), and writes the refreshed catalog to `Sources/ISOInspectorKit/Resources/MP4RABoxes.json`.
+   - By default the CLI targets the bundled file path. Use `--output <path>` to write to a scratch location for inspection, and `--source <url>` to test alternative registry endpoints.
+
+2. **Inspect metadata and diff.**
+   - Ensure the JSON now contains an updated `metadata` block with `source`, `fetchedAt` (UTC ISO8601 timestamp), and `recordCount` fields.
+   - Review the `git diff` to confirm the number of entries and any notable changes before committing.
+
+3. **Validate compatibility.**
+   - Run the full test suite to confirm `BoxCatalog` still decodes the refreshed file and downstream behaviour is unchanged.
+
+   ```bash
+   swift test
+   ```
+
+4. **Document the refresh.**
+   - Update any relevant task logs or research notes if the refresh resolves an open follow-up.
+   - Commit the regenerated JSON together with supporting documentation updates.
+
+## Troubleshooting
+
+- **Network failures:** rerun the command once connectivity is restored. The CLI prints the failing URL for quick diagnostics.
+- **Schema mismatches:** if MP4RA introduces new fields, extend `MP4RACatalogRefresher` and add regression tests before regenerating.
+- **Selective updates:** when validating locally without overwriting the bundled catalog, supply an alternate `--output` path and copy the file into place once reviewed.
+
+Keep this guide alongside future refreshes so contributors can execute the maintenance task without reverse-engineering prior changes.

--- a/Sources/ISOInspectorCLI/CLI.swift
+++ b/Sources/ISOInspectorCLI/CLI.swift
@@ -1,20 +1,141 @@
 import Foundation
 import ISOInspectorKit
 
+public struct ISOInspectorCLIEnvironment {
+    public var refreshCatalog: (_ source: URL, _ output: URL) throws -> Void
+    public var print: (String) -> Void
+    public var printError: (String) -> Void
+
+    public init(
+        refreshCatalog: @escaping (_ source: URL, _ output: URL) throws -> Void,
+        print: @escaping (String) -> Void = { Swift.print($0) },
+        printError: @escaping (String) -> Void = { message in fputs(message + "\n", stderr) }
+    ) {
+        self.refreshCatalog = refreshCatalog
+        self.print = print
+        self.printError = printError
+    }
+
+    public static let live = ISOInspectorCLIEnvironment { source, output in
+        let provider = HTTPMP4RARegistryDataProvider(sourceURL: source)
+        let refresher = MP4RACatalogRefresher(dataProvider: provider)
+        _ = try refresher.writeCatalog(to: output)
+    }
+}
+
 public enum ISOInspectorCLIRunner {
-    public static func run(arguments: [String] = CommandLine.arguments) {
-        if arguments.contains("--help") || arguments.contains("-h") {
-            print(helpText())
+    public static func run(
+        arguments: [String] = CommandLine.arguments,
+        environment: ISOInspectorCLIEnvironment = .live
+    ) {
+        let args = Array(arguments.dropFirst())
+
+        if args.contains("--help") || args.contains("-h") {
+            environment.print(helpText())
             return
         }
 
-        ISOInspectorCLIIO.printWelcome()
+        guard let first = args.first else {
+            ISOInspectorCLIIO.printWelcome()
+            return
+        }
+
+        switch first {
+        case "mp4ra":
+            handleMP4RACommand(Array(args.dropFirst()), environment: environment)
+        default:
+            ISOInspectorCLIIO.printWelcome()
+        }
     }
 
     public static func helpText() -> String {
         "isoinspect — ISO BMFF (MP4/QuickTime) inspector CLI\n" +
-        "  --help, -h    Show this help message.\n" +
-        "Additional subcommands will be introduced per tasks D1–D4 in the PRD."
+            "  --help, -h    Show this help message.\n" +
+            "  mp4ra refresh [--output <path>] [--source <url>]\n" +
+            "                Refresh the bundled MP4RABoxes.json using the latest registry export."
+    }
+
+    private static func handleMP4RACommand(
+        _ arguments: [String],
+        environment: ISOInspectorCLIEnvironment
+    ) {
+        guard let subcommand = arguments.first else {
+            environment.printError("mp4ra requires a subcommand. Try 'mp4ra refresh'.")
+            return
+        }
+
+        switch subcommand {
+        case "refresh":
+            switch parseRefreshOptions(Array(arguments.dropFirst())) {
+            case .success(let options):
+                do {
+                    try environment.refreshCatalog(options.source, options.output)
+                    environment.print("Refreshed MP4RA catalog → \(options.output.path)")
+                } catch {
+                    environment.printError("Failed to refresh MP4RA catalog: \(error)")
+                }
+            case .failure(let error):
+                environment.printError(error.message)
+            }
+        default:
+            environment.printError("Unknown mp4ra subcommand: \(subcommand)")
+        }
+    }
+
+    private struct RefreshOptions {
+        let source: URL
+        let output: URL
+    }
+
+    private enum RefreshParseError: Swift.Error {
+        case missingOutput
+        case invalidSource
+        case unknownOption(String)
+
+        var message: String {
+            switch self {
+            case .missingOutput:
+                return "Missing value for --output."
+            case .invalidSource:
+                return "Invalid value for --source."
+            case .unknownOption(let option):
+                return "Unknown option for mp4ra refresh: \(option)"
+            }
+        }
+    }
+
+    private static func parseRefreshOptions(
+        _ arguments: [String]
+    ) -> Result<RefreshOptions, RefreshParseError> {
+        var iterator = arguments.makeIterator()
+        var source = MP4RARegistryEndpoints.boxes
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        var output = cwd
+            .appendingPathComponent("Sources")
+            .appendingPathComponent("ISOInspectorKit")
+            .appendingPathComponent("Resources")
+            .appendingPathComponent("MP4RABoxes.json")
+            .standardizedFileURL
+
+        while let argument = iterator.next() {
+            switch argument {
+            case "--output", "-o":
+                guard let path = iterator.next() else {
+                    return .failure(.missingOutput)
+                }
+                let url = URL(fileURLWithPath: path, relativeTo: cwd)
+                output = url.standardizedFileURL
+            case "--source":
+                guard let value = iterator.next(), let url = URL(string: value) else {
+                    return .failure(.invalidSource)
+                }
+                source = url
+            default:
+                return .failure(.unknownOption(argument))
+            }
+        }
+
+        return .success(RefreshOptions(source: source, output: output))
     }
 }
 

--- a/Sources/ISOInspectorKit/Metadata/BoxCatalog.swift
+++ b/Sources/ISOInspectorKit/Metadata/BoxCatalog.swift
@@ -54,7 +54,6 @@ public struct BoxCatalog: Sendable {
 }
 
 extension BoxCatalog {
-    // @todo #2 Automate refreshing MP4RABoxes.json from the upstream registry and document the update workflow.
     static func loadBundledCatalog(logger: DiagnosticsLogger = DiagnosticsLogger(subsystem: "ISOInspectorKit", category: "BoxCatalog")) throws -> BoxCatalog {
         let loader = CatalogLoader(logger: logger)
         let entries = try loader.loadEntries()

--- a/Sources/ISOInspectorKit/Metadata/MP4RACatalogRefresher.swift
+++ b/Sources/ISOInspectorKit/Metadata/MP4RACatalogRefresher.swift
@@ -1,0 +1,404 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum MP4RARegistryEndpoints {
+    public static let boxes = URL(string: "https://mp4ra.org/api/boxes")!
+}
+
+public protocol MP4RARegistryDataProvider {
+    var sourceURL: URL { get }
+    func fetchRegistryPayload() throws -> Data
+}
+
+private final class MP4RAFetchResultBox: @unchecked Sendable {
+    var value: Result<(Data, URLResponse), Swift.Error>?
+}
+
+public struct HTTPMP4RARegistryDataProvider: MP4RARegistryDataProvider {
+    public enum Error: Swift.Error {
+        case invalidResponse
+        case httpStatus(Int)
+        case timeout
+        case emptyResponse
+    }
+
+    public let sourceURL: URL
+    private let session: URLSession
+    private let timeout: TimeInterval?
+
+    public init(sourceURL: URL = MP4RARegistryEndpoints.boxes, session: URLSession = .shared, timeout: TimeInterval? = 30) {
+        self.sourceURL = sourceURL
+        self.session = session
+        self.timeout = timeout
+    }
+
+    public func fetchRegistryPayload() throws -> Data {
+        let resultBox = MP4RAFetchResultBox()
+        let semaphore = DispatchSemaphore(value: 0)
+        let task = session.dataTask(with: sourceURL) { data, response, error in
+            if let error = error {
+                resultBox.value = .failure(error)
+            } else if let data = data, let response = response {
+                resultBox.value = .success((data, response))
+            } else {
+                resultBox.value = .failure(Error.emptyResponse)
+            }
+            semaphore.signal()
+        }
+        task.resume()
+
+        if let timeout {
+            let waitResult = semaphore.wait(timeout: .now() + timeout)
+            if waitResult == .timedOut {
+                task.cancel()
+                throw Error.timeout
+            }
+        } else {
+            semaphore.wait()
+        }
+
+        switch resultBox.value {
+        case .success(let payload):
+            guard let httpResponse = payload.1 as? HTTPURLResponse else {
+                throw Error.invalidResponse
+            }
+            guard 200 ..< 300 ~= httpResponse.statusCode else {
+                throw Error.httpStatus(httpResponse.statusCode)
+            }
+            guard !payload.0.isEmpty else {
+                throw Error.emptyResponse
+            }
+            return payload.0
+        case .failure(let error):
+            throw error
+        case .none:
+            throw Error.emptyResponse
+        }
+    }
+}
+
+public struct MP4RACatalogRefresher {
+    public struct Catalog: Codable, Equatable {
+        public struct Metadata: Codable, Equatable {
+            public let source: String
+            public let fetchedAt: String
+            public let recordCount: Int
+        }
+
+        public struct Entry: Codable, Equatable {
+            public let type: String
+            public let uuid: String?
+            public let name: String
+            public let summary: String
+            public let specification: String?
+            public let version: Int?
+            public let flags: String?
+        }
+
+        public let metadata: Metadata
+        public let boxes: [Entry]
+    }
+
+    private struct RemoteRecord: Decodable {
+        let code: String
+        let description: String
+        let specification: String?
+        let handler: String?
+        let category: String?
+        let objectType: String?
+
+        enum CodingKeys: String, CodingKey {
+            case code
+            case description
+            case specification
+            case handler
+            case category = "type"
+            case objectType = "ObjectType"
+        }
+    }
+
+    private let dataProvider: MP4RARegistryDataProvider
+    private let clock: () -> Date
+    private let isoFormatter: ISO8601DateFormatter
+
+    public init(dataProvider: MP4RARegistryDataProvider, clock: @escaping () -> Date = Date.init) {
+        self.dataProvider = dataProvider
+        self.clock = clock
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        self.isoFormatter = formatter
+    }
+
+    public func makeCatalog(baseline: Catalog? = nil) throws -> Catalog {
+        let payload = try dataProvider.fetchRegistryPayload()
+        let decoder = JSONDecoder()
+        let remoteRecords = try decoder.decode([RemoteRecord].self, from: payload)
+
+        var selected: [String: Catalog.Entry] = [:]
+        for record in remoteRecords {
+            guard let code = decodeFourCC(from: record.code) else { continue }
+            let name = makeName(from: record.description)
+            let summary = makeSummary(from: record)
+            let specification = sanitized(record.specification)
+            let entry = Catalog.Entry(
+                type: code,
+                uuid: nil,
+                name: name,
+                summary: summary,
+                specification: specification,
+                version: nil,
+                flags: nil
+            )
+
+            if let existing = selected[code] {
+                if shouldReplace(existing: existing, with: entry) {
+                    selected[code] = entry
+                }
+            } else {
+                selected[code] = entry
+            }
+        }
+
+        if let baseline {
+            selected = merge(selected, withBaseline: baseline)
+        }
+
+        let boxes = selected
+            .values
+            .sorted { lhs, rhs in lhs.type < rhs.type }
+        let metadata = Catalog.Metadata(
+            source: dataProvider.sourceURL.absoluteString,
+            fetchedAt: isoFormatter.string(from: clock()),
+            recordCount: boxes.count
+        )
+        return Catalog(metadata: metadata, boxes: boxes)
+    }
+
+    @discardableResult
+    public func writeCatalog(to url: URL) throws -> Catalog {
+        let baseline = loadBaselineCatalog(at: url)
+        let catalog = try makeCatalog(baseline: baseline)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(catalog)
+        try data.write(to: url, options: .atomic)
+        return catalog
+    }
+
+    private func loadBaselineCatalog(at url: URL) -> Catalog? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        do {
+            let data = try Data(contentsOf: url)
+            let decoder = JSONDecoder()
+            if let catalog = try? decoder.decode(Catalog.self, from: data) {
+                return catalog
+            }
+            if let legacy = try? decoder.decode(LegacyCatalog.self, from: data) {
+                let entries = legacy.boxes.map { entry -> Catalog.Entry in
+                    Catalog.Entry(
+                        type: entry.type,
+                        uuid: entry.uuid,
+                        name: entry.name,
+                        summary: entry.summary,
+                        specification: entry.specification,
+                        version: entry.version,
+                        flags: entry.flags
+                    )
+                }
+                return Catalog(
+                    metadata: Catalog.Metadata(
+                        source: "legacy",
+                        fetchedAt: "",
+                        recordCount: entries.count
+                    ),
+                    boxes: entries
+                )
+            }
+            return nil
+        } catch {
+            return nil
+        }
+    }
+
+    private func decodeFourCC(from rawCode: String) -> String? {
+        var output = ""
+        var index = rawCode.startIndex
+        while index < rawCode.endIndex {
+            let character = rawCode[index]
+            if character == "$" {
+                let start = rawCode.index(after: index)
+                let end = rawCode.index(start, offsetBy: 2, limitedBy: rawCode.endIndex) ?? rawCode.endIndex
+                guard end <= rawCode.endIndex else { return nil }
+                let hexString = String(rawCode[start..<end])
+                guard hexString.count == 2,
+                      let value = UInt8(hexString, radix: 16),
+                      let scalar = UnicodeScalar(Int(value)) else {
+                    return nil
+                }
+                output.append(Character(scalar))
+                index = end
+                continue
+            }
+
+            if character == " " || character == "\t" || character == "\n" || character == "\r" {
+                index = rawCode.index(after: index)
+                continue
+            }
+
+            output.append(character)
+            index = rawCode.index(after: index)
+        }
+
+        guard output.utf8.count == 4 else { return nil }
+        return output
+    }
+
+    private func makeSummary(from record: RemoteRecord) -> String {
+        let base = collapseWhitespace(record.description)
+        var components: [String] = []
+        if let handler = sanitized(record.handler) {
+            components.append("handler: \(handler)")
+        }
+        if let category = sanitized(record.category) {
+            components.append("category: \(category)")
+        }
+        if let objectType = sanitized(record.objectType) {
+            components.append("objectType: \(objectType)")
+        }
+        guard !components.isEmpty else { return base }
+        return "\(base) (\(components.joined(separator: ", ")))"
+    }
+
+    private func makeName(from description: String) -> String {
+        let collapsed = collapseWhitespace(description)
+        guard !collapsed.isEmpty else { return "" }
+        let words = collapsed.split(separator: " ")
+        return words.map { word -> String in
+            let token = String(word)
+            if token.allSatisfy({ !$0.isLetter || $0.isUppercase }) {
+                return token
+            }
+            guard let first = token.first else { return token }
+            return String(first).uppercased() + token.dropFirst()
+        }.joined(separator: " ")
+    }
+
+    private func collapseWhitespace(_ text: String) -> String {
+        text.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+    }
+
+    private func merge(
+        _ selected: [String: Catalog.Entry],
+        withBaseline baseline: Catalog
+    ) -> [String: Catalog.Entry] {
+        var merged = selected
+        for entry in baseline.boxes {
+            if let existing = merged[entry.type] {
+                merged[entry.type] = merge(remote: existing, baseline: entry)
+            } else {
+                merged[entry.type] = entry
+            }
+        }
+        return merged
+    }
+
+    private func merge(remote: Catalog.Entry, baseline: Catalog.Entry) -> Catalog.Entry {
+        let uuid = remote.uuid ?? baseline.uuid
+        let preferBaselineDetails = remote.uuid == nil && baseline.uuid != nil
+        return Catalog.Entry(
+            type: remote.type,
+            uuid: uuid,
+            name: preferBaselineDetails ? baseline.name : preferredName(remote.name, baseline.name),
+            summary: preferBaselineDetails ? baseline.summary : preferredSummary(remote.summary, baseline.summary),
+            specification: preferBaselineDetails ? baseline.specification : preferredSpecification(remote.specification, baseline.specification),
+            version: remote.version ?? baseline.version,
+            flags: remote.flags ?? baseline.flags
+        )
+    }
+
+    private func preferredName(_ remote: String, _ baseline: String) -> String {
+        let trimmedRemote = collapseWhitespace(remote)
+        if trimmedRemote.isEmpty {
+            return collapseWhitespace(baseline)
+        }
+        return trimmedRemote
+    }
+
+    private func preferredSummary(_ remote: String, _ baseline: String) -> String {
+        let trimmedRemote = collapseWhitespace(remote)
+        let trimmedBaseline = collapseWhitespace(baseline)
+        if trimmedRemote.isEmpty {
+            return trimmedBaseline
+        }
+        if trimmedBaseline.isEmpty {
+            return trimmedRemote
+        }
+        if trimmedRemote.count >= trimmedBaseline.count {
+            return trimmedRemote
+        }
+        return trimmedBaseline
+    }
+
+    private func preferredSpecification(_ remote: String?, _ baseline: String?) -> String? {
+        let trimmedRemote = remote.flatMap { value -> String in
+            let collapsed = collapseWhitespace(value)
+            return collapsed
+        }
+        let trimmedBaseline = baseline.flatMap { value -> String in
+            let collapsed = collapseWhitespace(value)
+            return collapsed
+        }
+
+        switch (trimmedRemote?.isEmpty ?? true, trimmedBaseline?.isEmpty ?? true) {
+        case (false, true):
+            return trimmedRemote
+        case (true, false):
+            return trimmedBaseline
+        case (false, false):
+            if (trimmedRemote?.count ?? 0) >= (trimmedBaseline?.count ?? 0) {
+                return trimmedRemote
+            }
+            return trimmedBaseline
+        default:
+            return nil
+        }
+    }
+
+    private func sanitized(_ value: String?) -> String? {
+        guard let value = value else { return nil }
+        let collapsed = collapseWhitespace(value)
+        return collapsed.isEmpty ? nil : collapsed
+    }
+
+    private func shouldReplace(existing: Catalog.Entry, with candidate: Catalog.Entry) -> Bool {
+        let existingHasSpec = !(existing.specification?.isEmpty ?? true)
+        let candidateHasSpec = !(candidate.specification?.isEmpty ?? true)
+        if !existingHasSpec && candidateHasSpec {
+            return true
+        }
+
+        let existingHasDetails = existing.summary.contains("(")
+        let candidateHasDetails = candidate.summary.contains("(")
+        if !existingHasDetails && candidateHasDetails {
+            return true
+        }
+
+        return false
+    }
+}
+
+private struct LegacyCatalog: Decodable {
+    struct Entry: Decodable {
+        let type: String
+        let uuid: String?
+        let name: String
+        let summary: String
+        let specification: String?
+        let version: Int?
+        let flags: String?
+    }
+
+    let boxes: [Entry]
+}

--- a/Sources/ISOInspectorKit/Resources/MP4RABoxes.json
+++ b/Sources/ISOInspectorKit/Resources/MP4RABoxes.json
@@ -1,53 +1,7014 @@
 {
-  "boxes": [
+  "boxes" : [
     {
-      "type": "ftyp",
-      "name": "File Type Box",
-      "summary": "Identifies the file type and compatibility brands for the bitstream.",
-      "specification": "ISO/IEC 14496-12",
-      "version": null,
-      "flags": null
+      "name" : "Compressed Movie Fragment",
+      "specification" : "ISO",
+      "summary" : "Compressed movie fragment",
+      "type" : "!mof"
     },
     {
-      "type": "moov",
-      "name": "Movie Box",
-      "summary": "Top-level container for movie metadata including tracks and timing information.",
-      "specification": "ISO/IEC 14496-12",
-      "version": null,
-      "flags": null
+      "name" : "Compressed Movie",
+      "specification" : "ISO",
+      "summary" : "Compressed movie",
+      "type" : "!mov"
     },
     {
-      "type": "trak",
-      "name": "Track Box",
-      "summary": "Container describing a single track within the presentation.",
-      "specification": "ISO/IEC 14496-12",
-      "version": null,
-      "flags": null
+      "name" : "Compressed Segment Index",
+      "specification" : "ISO",
+      "summary" : "Compressed segment index",
+      "type" : "!six"
     },
     {
-      "type": "tkhd",
-      "name": "Track Header Box",
-      "summary": "Defines the characteristics of a track, including ID, duration, and display parameters.",
-      "specification": "ISO/IEC 14496-12",
-      "version": 0,
-      "flags": "000007"
+      "name" : "Compressed Subsegment Index",
+      "specification" : "ISO",
+      "summary" : "Compressed subsegment index",
+      "type" : "!ssx"
     },
     {
-      "type": "mdat",
-      "name": "Media Data Box",
-      "summary": "Holds the raw media samples referenced by the track sample tables.",
-      "specification": "ISO/IEC 14496-12",
-      "version": null,
-      "flags": null
+      "name" : "Single Intra-coded Picture",
+      "specification" : "HEIF",
+      "summary" : "Single intra-coded picture",
+      "type" : "1pic"
     },
     {
-      "type": "uuid",
-      "uuid": "D4807EF2-CA39-4695-8E54-26CB9E46A79F",
-      "name": "KLV Sample Entry",
-      "summary": "Carries SMPTE KLV sample metadata using a registered UUID container.",
-      "specification": "SMPTE ST 336",
-      "version": null,
-      "flags": null
+      "name" : "2D Cartesian Coordinates",
+      "specification" : "Metrics",
+      "summary" : "2D cartesian coordinates (handler: Metadata)",
+      "type" : "2dcc"
+    },
+    {
+      "name" : "2D Region Quality Ranking",
+      "specification" : "OMAF",
+      "summary" : "2D region quality ranking",
+      "type" : "2dqr"
+    },
+    {
+      "name" : "Two Dimensional Spatial Relationship Sample Grouping",
+      "specification" : "OMAF",
+      "summary" : "Two dimensional spatial relationship sample grouping (category: sample group)",
+      "type" : "2dsr"
+    },
+    {
+      "name" : "Spatial Relationship 2D Source",
+      "specification" : "OMAF",
+      "summary" : "spatial relationship 2D source",
+      "type" : "2dss"
+    },
+    {
+      "name" : "8 Bit Per Component YUV 4:2:2. Packed Cb Y0 Cr Y1",
+      "specification" : "Apple",
+      "summary" : "8 bit per component YUV 4:2:2. Packed Cb Y0 Cr Y1",
+      "type" : "2vuy"
+    },
+    {
+      "name" : "MVDDepthResolutionBox",
+      "specification" : "NALu Video",
+      "summary" : "MVDDepthResolutionBox",
+      "type" : "3dpr"
+    },
+    {
+      "name" : "3GPP2",
+      "specification" : "3GPP2",
+      "summary" : "3GPP2",
+      "type" : "3g2a"
+    },
+    {
+      "name" : "3GPP PSS Annex G Video Buffer Parameters",
+      "specification" : "3GPP",
+      "summary" : "3GPP PSS Annex G video buffer parameters (category: sample group)",
+      "type" : "3gag"
+    },
+    {
+      "name" : "3GPP Release 6 Extended-presentation Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 6 extended-presentation Profile",
+      "type" : "3ge6"
+    },
+    {
+      "name" : "3GPP Release 7 Extended-presentation Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 7 extended-presentation Profile",
+      "type" : "3ge7"
+    },
+    {
+      "name" : "3GPP Release 9 Extended Presentation Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Extended Presentation Profile",
+      "type" : "3ge9"
+    },
+    {
+      "name" : "3GPP Release 9 File-delivery Server Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 File-delivery Server Profile",
+      "type" : "3gf9"
+    },
+    {
+      "name" : "3GPP Release 6 General Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 6 General Profile",
+      "type" : "3gg6"
+    },
+    {
+      "name" : "3GPP Release 9 General Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 General Profile",
+      "type" : "3gg9"
+    },
+    {
+      "name" : "3GPP Release 9 Adaptive Streaming Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Adaptive Streaming Profile",
+      "type" : "3gh9"
+    },
+    {
+      "name" : "3GPP Location",
+      "specification" : "3GPP",
+      "summary" : "3GPP Location (handler: Metadata)",
+      "type" : "3glo"
+    },
+    {
+      "name" : "3GPP Release 9 Media Segment Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Media Segment Profile",
+      "type" : "3gm9"
+    },
+    {
+      "name" : "3GPP Media Segment Conforming To The Media Segment Format For 3GP DASH",
+      "specification" : "3GPP-DASH",
+      "summary" : "3GPP Media Segment conforming to the Media Segment Format for 3GP DASH",
+      "type" : "3gmA"
+    },
+    {
+      "name" : "3GPP Orientation",
+      "specification" : "3GPP",
+      "summary" : "3GPP Orientation (handler: Metadata)",
+      "type" : "3gor"
+    },
+    {
+      "name" : "3GPP Release 4",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 4",
+      "type" : "3gp4"
+    },
+    {
+      "name" : "3GPP Release 5",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 5",
+      "type" : "3gp5"
+    },
+    {
+      "name" : "3GPP Release 6 Basic Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 6 basic Profile",
+      "type" : "3gp6"
+    },
+    {
+      "name" : "3GPP Release 7",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 7",
+      "type" : "3gp7"
+    },
+    {
+      "name" : "3GPP Release 8",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 8",
+      "type" : "3gp8"
+    },
+    {
+      "name" : "3GPP Release 9 Basic Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Basic Profile",
+      "type" : "3gp9"
+    },
+    {
+      "name" : "3GPP Release 6 Progressive-download Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 6 progressive-download Profile",
+      "type" : "3gr6"
+    },
+    {
+      "name" : "3GPP Release 9 Progressive DownloadProfile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Progressive DownloadProfile",
+      "type" : "3gr9"
+    },
+    {
+      "name" : "3GPP Release 6 Streaming-server Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 6 streaming-server Profile",
+      "type" : "3gs6"
+    },
+    {
+      "name" : "3GPP Release 9 Streaming ServerProfile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Streaming ServerProfile",
+      "type" : "3gs9"
+    },
+    {
+      "name" : "3GPP Scene Description",
+      "specification" : "3GPP",
+      "summary" : "3GPP Scene Description (category: handler)",
+      "type" : "3gsd"
+    },
+    {
+      "name" : "3GPP Release 8 Media Stream Recording Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 8 Media Stream Recording Profile",
+      "type" : "3gt8"
+    },
+    {
+      "name" : "3GPP Release 9 Media Stream Recording Profile",
+      "specification" : "3GPP",
+      "summary" : "3GPP Release 9 Media Stream Recording Profile",
+      "type" : "3gt9"
+    },
+    {
+      "name" : "3GPP TV Over 3GPP Services",
+      "specification" : "3GPP-TVP",
+      "summary" : "3GPP TV over 3GPP services",
+      "type" : "3gtv"
+    },
+    {
+      "name" : "3GPP Video Orientation",
+      "specification" : "3GPP",
+      "summary" : "3GPP Video Orientation (handler: Metadata)",
+      "type" : "3gvo"
+    },
+    {
+      "name" : "3GPP VR Presentation",
+      "specification" : "3GPP-VR",
+      "summary" : "3GPP VR Presentation",
+      "type" : "3gvr"
+    },
+    {
+      "name" : "MVD Scalability Information SEI Message Box",
+      "specification" : "NALu Video",
+      "summary" : "MVD Scalability Information SEI Message Box (handler: Video)",
+      "type" : "3sib"
+    },
+    {
+      "name" : "3GPP VR Advanced Video Media Profile",
+      "specification" : "3GPP-VR",
+      "summary" : "3GPP VR Advanced Video Media Profile",
+      "type" : "3vra"
+    },
+    {
+      "name" : "3GPP VR Basic Video Media Profile",
+      "specification" : "3GPP-VR",
+      "summary" : "3GPP VR Basic Video Media Profile",
+      "type" : "3vrb"
+    },
+    {
+      "name" : "3GPP VR Main Video Media Profile",
+      "specification" : "3GPP-VR",
+      "summary" : "3GPP VR Main Video Media Profile",
+      "type" : "3vrm"
+    },
+    {
+      "name" : "Viewport Configuration",
+      "specification" : "V3C-SYS",
+      "summary" : "Viewport Configuration (handler: Volumetric visual media)",
+      "type" : "6vpC"
+    },
+    {
+      "name" : "Dynamic Viewport Data",
+      "specification" : "V3C-SYS",
+      "summary" : "Dynamic viewport data (handler: Volumetric visual media)",
+      "type" : "6vpt"
+    },
+    {
+      "name" : "ARRI Digital Camera",
+      "specification" : "ARRI",
+      "summary" : "ARRI Digital Camera",
+      "type" : "ARRI"
+    },
+    {
+      "name" : "Canon Digital Camera",
+      "specification" : "Canon",
+      "summary" : "Canon Digital Camera",
+      "type" : "CAEP"
+    },
+    {
+      "name" : "Convergent Designs",
+      "specification" : "Convergent",
+      "summary" : "Convergent Designs",
+      "type" : "CDes"
+    },
+    {
+      "name" : "Content Light Level Box",
+      "specification" : "VPxx",
+      "summary" : "Content Light Level Box (handler: Video)",
+      "type" : "CoLL"
+    },
+    {
+      "name" : "EXIF Item",
+      "specification" : "HEIF",
+      "summary" : "EXIF item",
+      "type" : "Exif"
+    },
+    {
+      "name" : "An Open Lossless Intra-frame Video Codec",
+      "specification" : "FF Video Codec",
+      "summary" : "An open lossless intra-frame video codec (handler: Video)",
+      "type" : "FFV1"
+    },
+    {
+      "name" : "Subtitle Graphics",
+      "specification" : "Sony",
+      "summary" : "Subtitle Graphics (category: handler)",
+      "type" : "GRAP"
+    },
+    {
+      "name" : "ID3 Version 2 Meta-data Handler (meta Box)",
+      "specification" : "id3v2",
+      "summary" : "ID3 version 2 meta-data handler (meta box) (category: handler)",
+      "type" : "ID32"
+    },
+    {
+      "name" : "JPEG2000 Profile 0",
+      "specification" : "JPEG2000",
+      "summary" : "JPEG2000 Profile 0",
+      "type" : "J2P0"
+    },
+    {
+      "name" : "JPEG2000 Profile 1",
+      "specification" : "JPEG2000",
+      "summary" : "JPEG2000 Profile 1",
+      "type" : "J2P1"
+    },
+    {
+      "name" : "JPEG XL Signature",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL Signature",
+      "type" : "JXL "
+    },
+    {
+      "name" : "JPEG XS Signature",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Signature",
+      "type" : "JXS "
+    },
+    {
+      "name" : "Leica Digital Camera",
+      "specification" : "Leica",
+      "summary" : "Leica digital camera",
+      "type" : "LCAG"
+    },
+    {
+      "name" : "ITunes MPEG-4 Audio Protected Or Not, Can Contain Audio + Video + 3g Text Track + Chapter Track",
+      "specification" : "iTunes",
+      "summary" : "iTunes MPEG-4 audio protected or not, can contain audio + video + 3g text track + chapter track",
+      "type" : "M4A "
+    },
+    {
+      "name" : "ITunes AudioBook Protected Or Not, Can Contain Audio + Video + 3g Text Track + Chapter Track",
+      "specification" : "iTunes",
+      "summary" : "iTunes AudioBook protected or not, can contain audio + video + 3g text track + chapter track",
+      "type" : "M4B "
+    },
+    {
+      "name" : "MPEG-4 Protected Audio",
+      "specification" : "iTunes",
+      "summary" : "MPEG-4 protected audio",
+      "type" : "M4P "
+    },
+    {
+      "name" : "MPEG-4 Protected Audio+video",
+      "specification" : "iTunes",
+      "summary" : "MPEG-4 protected audio+video",
+      "type" : "M4V "
+    },
+    {
+      "name" : "AVIF Advanced Profile",
+      "specification" : "AVIF",
+      "summary" : "AVIF Advanced Profile",
+      "type" : "MA1A"
+    },
+    {
+      "name" : "AVIF Baseline Profile",
+      "specification" : "AVIF",
+      "summary" : "AVIF Baseline Profile",
+      "type" : "MA1B"
+    },
+    {
+      "name" : "Media File For Samsung Video Metadata",
+      "specification" : "Samsung",
+      "summary" : "Media File for Samsung video Metadata",
+      "type" : "MFSM"
+    },
+    {
+      "name" : "Home And Mobile Multimedia Platform (HMMP)",
+      "specification" : "Sony",
+      "summary" : "Home and Mobile Multimedia Platform (HMMP)",
+      "type" : "MGSV"
+    },
+    {
+      "name" : "QuickTime MPEG Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime MPEG track handler (category: handler)",
+      "type" : "MPEG"
+    },
+    {
+      "name" : "Photo Player Multimedia Application Format",
+      "specification" : "ISO-MAF",
+      "summary" : "Photo Player Multimedia Application Format",
+      "type" : "MPPI"
+    },
+    {
+      "name" : "Portable Multimedia CE Products Using MP4 File Format With AVC Video Codec And AAC Audio Codec",
+      "specification" : "IEC 62592",
+      "summary" : "Portable multimedia CE products using MP4 file format with AVC video codec and AAC audio codec",
+      "type" : "MSNV"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For MIAF AVC Basic Profile",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for MIAF AVC Basic Profile",
+      "type" : "MiAB"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For Fragmented Alpha Video",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for fragmented alpha video",
+      "type" : "MiAC"
+    },
+    {
+      "name" : "Mutli-Image Application Format Brand For Animation",
+      "specification" : "MIAF",
+      "summary" : "Mutli-Image Application format brand for animation",
+      "type" : "MiAn"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For Burst Capture",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for burst capture",
+      "type" : "MiBu"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For CMAF Compatibility",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for CMAF compatibility",
+      "type" : "MiCm"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For MIAF HEVC Advanced Profile",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for MIAF HEVC Advanced Profile",
+      "type" : "MiHA"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For MIAF HEVC Basic Profile",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for MIAF HEVC Basic Profile",
+      "type" : "MiHB"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For MIAF HEVC Extended Profile",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for MIAF HEVC Extended Profile",
+      "type" : "MiHE"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For Progressive Decoding And Rendering",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for progressive decoding and rendering",
+      "type" : "MiPr"
+    },
+    {
+      "name" : "Opus Audio Coding",
+      "specification" : "Opus",
+      "summary" : "Opus audio coding (handler: Audio, objectType: 0xAD)",
+      "type" : "Opus"
+    },
+    {
+      "name" : "Ross Video",
+      "specification" : "Ross",
+      "summary" : "Ross Video",
+      "type" : "ROSS"
+    },
+    {
+      "name" : "Home And Mobile Multimedia Platform (HMMP)",
+      "specification" : "Sony",
+      "summary" : "Home and Mobile Multimedia Platform (HMMP)",
+      "type" : "SEAU"
+    },
+    {
+      "name" : "Home And Mobile Multimedia Platform (HMMP)",
+      "specification" : "Sony",
+      "summary" : "Home and Mobile Multimedia Platform (HMMP)",
+      "type" : "SEBK"
+    },
+    {
+      "name" : "Subtitle Sample Entry (HMMP)",
+      "specification" : "Sony",
+      "summary" : "Subtitle Sample Entry (HMMP) (handler: Subtitle Graphics)",
+      "type" : "STGS"
+    },
+    {
+      "name" : "Mastering Display Metadata Box",
+      "specification" : "VPxx",
+      "summary" : "Mastering Display Metadata Box (handler: Video)",
+      "type" : "SmDm"
+    },
+    {
+      "name" : "Unique Identifier Technology Solution",
+      "specification" : "Universal Music Group",
+      "summary" : "Unique Identifier Technology Solution",
+      "type" : "UITS"
+    },
+    {
+      "name" : "XAVC File Format",
+      "specification" : "Sony",
+      "summary" : "XAVC File Format",
+      "type" : "XAVC"
+    },
+    {
+      "name" : "XF-AVC S\/XF-HEVC S File Format",
+      "specification" : "Canon",
+      "summary" : "XF-AVC S\/XF-HEVC S File Format",
+      "type" : "XFVC"
+    },
+    {
+      "name" : "3D-AVC Track With 3D-AVC NAL Units Only",
+      "specification" : "NALu Video",
+      "summary" : "3D-AVC track with 3D-AVC NAL units only (handler: Video)",
+      "type" : "a3d1"
+    },
+    {
+      "name" : "3D-AVC Track With 3D-AVC NAL Units Only",
+      "specification" : "NALu Video",
+      "summary" : "3D-AVC track with 3D-AVC NAL units only (handler: Video)",
+      "type" : "a3d2"
+    },
+    {
+      "name" : "3D-AVC Track With 3D-AVC NAL Units Only",
+      "specification" : "NALu Video",
+      "summary" : "3D-AVC track with 3D-AVC NAL units only (handler: Video)",
+      "type" : "a3d3"
+    },
+    {
+      "name" : "3D-AVC Track With 3D-AVC NAL Units Only",
+      "specification" : "NALu Video",
+      "summary" : "3D-AVC track with 3D-AVC NAL units only (handler: Video)",
+      "type" : "a3d4"
+    },
+    {
+      "name" : "A3DConfigurationBox",
+      "specification" : "NALu Video",
+      "summary" : "A3DConfigurationBox (handler: Video)",
+      "type" : "a3dC"
+    },
+    {
+      "name" : "Auro-Cx 3D Audio",
+      "specification" : "Auro",
+      "summary" : "Auro-Cx 3D audio (handler: Audio, objectType: 0xAF)",
+      "type" : "a3ds"
+    },
+    {
+      "name" : "SEI-restricted Video",
+      "specification" : "NALu Video",
+      "summary" : "SEI-restricted video (category: restricted video scheme)",
+      "type" : "aSEI"
+    },
+    {
+      "name" : "RGBA 32bits Packed",
+      "specification" : "UNCV",
+      "summary" : "RGBA 32bits packed",
+      "type" : "abgr"
+    },
+    {
+      "name" : "AC-3 Audio",
+      "specification" : "ETSI AC-3",
+      "summary" : "AC-3 audio (handler: Audio, objectType: 0xA5)",
+      "type" : "ac-3"
+    },
+    {
+      "name" : "AC-4 Audio",
+      "specification" : "ETSI AC-4",
+      "summary" : "AC-4 audio (handler: Audio, objectType: 0xAE)",
+      "type" : "ac-4"
+    },
+    {
+      "name" : "Group Of VVC Subpicture Tracks With Common Properties",
+      "specification" : "NALu Video",
+      "summary" : "group of VVC subpicture tracks with common properties",
+      "type" : "acgl"
+    },
+    {
+      "name" : "Decoder-specific Info For Auro-Cx Audio",
+      "specification" : "Auro",
+      "summary" : "Decoder-specific info for Auro-Cx audio (handler: Audio)",
+      "type" : "acxd"
+    },
+    {
+      "name" : "Additional Audio Track",
+      "specification" : "ISO",
+      "summary" : "Additional audio track",
+      "type" : "adda"
+    },
+    {
+      "name" : "Description Of The Content For Accessibility Purposes (similar To The HTML Alt Attribute); Formatted As For The Cprt User-data Item",
+      "specification" : "Apple",
+      "summary" : "description of the content for accessibility purposes (similar to the HTML alt attribute); formatted as for the cprt user-data item",
+      "type" : "ades"
+    },
+    {
+      "name" : "DRC Metadata Track",
+      "specification" : "ISO",
+      "summary" : "DRC metadata track",
+      "type" : "adrc"
+    },
+    {
+      "name" : "Advanced Tiling OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "Advanced tiling OMAF video profile",
+      "type" : "adti"
+    },
+    {
+      "name" : "Auto Exposure Bracketing",
+      "specification" : "HEIF",
+      "summary" : "Auto exposure bracketing (category: sample group)",
+      "type" : "aebr"
+    },
+    {
+      "name" : "Audio Element Description",
+      "specification" : "ISO",
+      "summary" : "audio element description",
+      "type" : "aedb"
+    },
+    {
+      "name" : "Audio Element Box",
+      "specification" : "ISO",
+      "summary" : "audio element box",
+      "type" : "aelm"
+    },
+    {
+      "name" : "Audio Element Positioning Interactivity Polar Box",
+      "specification" : "ISO",
+      "summary" : "audio element positioning interactivity polar box",
+      "type" : "aepp"
+    },
+    {
+      "name" : "Audio Element Prominence Interactivity Box",
+      "specification" : "ISO",
+      "summary" : "audio element prominence interactivity box",
+      "type" : "aepr"
+    },
+    {
+      "name" : "Audio Element Selection Box",
+      "specification" : "ISO",
+      "summary" : "audio element selection box",
+      "type" : "aesb"
+    },
+    {
+      "name" : "Audio Element Selection Description Box",
+      "specification" : "ISO",
+      "summary" : "audio element selection description box",
+      "type" : "aesd"
+    },
+    {
+      "name" : "Associated External Stream Track",
+      "specification" : "ISO",
+      "summary" : "associated external stream track",
+      "type" : "aest"
+    },
+    {
+      "name" : "Flash Exposure Bracketing",
+      "specification" : "HEIF",
+      "summary" : "Flash exposure bracketing (category: sample group)",
+      "type" : "afbr"
+    },
+    {
+      "name" : "ID3 Metadata Carried As Timed Metadata In CMAF",
+      "specification" : "CMAF-ID3",
+      "summary" : "ID3 metadata carried as timed metadata in CMAF",
+      "type" : "aid3"
+    },
+    {
+      "name" : "Asset Information To Identify, License And Play",
+      "specification" : "DECE",
+      "summary" : "Asset information to identify, license and play",
+      "type" : "ainf"
+    },
+    {
+      "name" : "Apple Lossless Audio Codec",
+      "specification" : "Apple",
+      "summary" : "Apple lossless audio codec (handler: Audio)",
+      "type" : "alac"
+    },
+    {
+      "name" : "A-Law",
+      "specification" : "QT",
+      "summary" : "a-Law (handler: Audio)",
+      "type" : "alaw"
+    },
+    {
+      "name" : "Album Collection Entity Group",
+      "specification" : "HEIF",
+      "summary" : "Album Collection entity group",
+      "type" : "albc"
+    },
+    {
+      "name" : "Album Title And Track Number For Media",
+      "specification" : "3GPP",
+      "summary" : "Album title and track number for media",
+      "type" : "albm"
+    },
+    {
+      "name" : "Alpha Mode (straight Vs Premultiplied Alpha) Signaling",
+      "specification" : "Apple",
+      "summary" : "Alpha mode (straight vs premultiplied alpha) signaling (handler: Video)",
+      "type" : "almo"
+    },
+    {
+      "name" : "Album Loudness Base",
+      "specification" : "ISO",
+      "summary" : "Album loudness base",
+      "type" : "alou"
+    },
+    {
+      "name" : "Alternative Startup Sequence",
+      "specification" : "ISO",
+      "summary" : "Alternative startup sequence (category: sample group)",
+      "type" : "alst"
+    },
+    {
+      "name" : "Alternative Extraction Source Track Grouping",
+      "specification" : "NALu Video",
+      "summary" : "alternative extraction source track grouping",
+      "type" : "alte"
+    },
+    {
+      "name" : "Alternative Entity Grouping",
+      "specification" : "ISO",
+      "summary" : "alternative entity grouping",
+      "type" : "altr"
+    },
+    {
+      "name" : "Accessibility Text",
+      "specification" : "HEIF",
+      "summary" : "Accessibility text",
+      "type" : "altt"
+    },
+    {
+      "name" : "Group Of VVC Subpicture Tracks With Different Properties",
+      "specification" : "NALu Video",
+      "summary" : "group of VVC subpicture tracks with different properties",
+      "type" : "amgl"
+    },
+    {
+      "name" : "Ambient Viewing Environment",
+      "specification" : "ISO",
+      "summary" : "Ambient viewing environment (handler: Video)",
+      "type" : "amve"
+    },
+    {
+      "name" : "Name Of The Camera Angle Through Which The Clip Was Shot",
+      "specification" : "Apple",
+      "summary" : "Name of the camera angle through which the clip was shot",
+      "type" : "angl"
+    },
+    {
+      "name" : "Apple Positional Audio Codec",
+      "specification" : "Apple",
+      "summary" : "Apple Positional Audio Codec (handler: Audio)",
+      "type" : "apac"
+    },
+    {
+      "name" : "APV Mezzanine Video Codec For Storage Exchange And Editing Of Professional Quality Video",
+      "specification" : "OpenAPV",
+      "summary" : "APV mezzanine video codec for storage exchange and editing of professional quality video (handler: Video)",
+      "type" : "apv1"
+    },
+    {
+      "name" : "APV Codec Configuration Box",
+      "specification" : "OpenAPV",
+      "summary" : "APV Codec Configuration Box (handler: Video)",
+      "type" : "apvC"
+    },
+    {
+      "name" : "Audio Rendering Indication",
+      "specification" : "ISO",
+      "summary" : "audio rendering indication",
+      "type" : "ardi"
+    },
+    {
+      "name" : "Alternative Startup Sequence Properties",
+      "specification" : "ISO",
+      "summary" : "alternative startup sequence properties",
+      "type" : "assp"
+    },
+    {
+      "name" : "Access Unit Delimiter",
+      "specification" : "NALu Video",
+      "summary" : "Access unit delimiter (category: sample group)",
+      "type" : "aud "
+    },
+    {
+      "name" : "Author Of The Media",
+      "specification" : "3GPP",
+      "summary" : "Author of the media",
+      "type" : "auth"
+    },
+    {
+      "name" : "Auxiliary Video Descriptor",
+      "specification" : "ISO",
+      "summary" : "Auxiliary Video descriptor",
+      "type" : "auvd"
+    },
+    {
+      "name" : "Auxiliary Type",
+      "specification" : "HEIF",
+      "summary" : "Auxiliary type",
+      "type" : "auxC"
+    },
+    {
+      "name" : "AuxiliaryTypeInfoBox",
+      "specification" : "HEIF",
+      "summary" : "AuxiliaryTypeInfoBox (handler: Video)",
+      "type" : "auxi"
+    },
+    {
+      "name" : "Auxiliary Image Item Reference",
+      "specification" : "HEIF",
+      "summary" : "Auxiliary image item reference (category: item ref.)",
+      "type" : "auxl"
+    },
+    {
+      "name" : "Auxiliary Video",
+      "specification" : "ISO",
+      "summary" : "Auxiliary video (category: handler)",
+      "type" : "auxv"
+    },
+    {
+      "name" : "AOM Video Codec",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AOM Video Codec (handler: Video)",
+      "type" : "av01"
+    },
+    {
+      "name" : "AOM Video Codec Configuration",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AOM Video Codec Configuration (handler: Video)",
+      "type" : "av1C"
+    },
+    {
+      "name" : "AV1 Metadata",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AV1 Metadata (category: sample group)",
+      "type" : "av1M"
+    },
+    {
+      "name" : "AV1 Forward Key Frame",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AV1 Forward Key Frame (category: sample group)",
+      "type" : "av1f"
+    },
+    {
+      "name" : "AV1 Multi-Frame",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AV1 Multi-Frame (category: sample group)",
+      "type" : "av1m"
+    },
+    {
+      "name" : "AV1 Switch Frame",
+      "specification" : "AV1-ISOBMFF",
+      "summary" : "AV1 Switch Frame (category: sample group)",
+      "type" : "av1s"
+    },
+    {
+      "name" : "AVS3-P3 Codec",
+      "specification" : "T-AI-109.7",
+      "summary" : "AVS3-P3 Codec (handler: Audio, objectType: 0xF1)",
+      "type" : "av3a"
+    },
+    {
+      "name" : "Advanced Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Advanced Video Coding (handler: Video, objectType: 0x21)",
+      "type" : "avc1"
+    },
+    {
+      "name" : "Advanced Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Advanced Video Coding (handler: Video, objectType: 0x21)",
+      "type" : "avc2"
+    },
+    {
+      "name" : "Advanced Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Advanced Video Coding (handler: Video, objectType: 0x21)",
+      "type" : "avc3"
+    },
+    {
+      "name" : "Advanced Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Advanced Video Coding (handler: Video, objectType: 0x21)",
+      "type" : "avc4"
+    },
+    {
+      "name" : "AVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "AVC Configuration (handler: Video)",
+      "type" : "avcC"
+    },
+    {
+      "name" : "AVC HRD Parameters",
+      "specification" : "3GPP",
+      "summary" : "AVC HRD parameters (category: sample group)",
+      "type" : "avcb"
+    },
+    {
+      "name" : "AVC Image And Image Collection Brands",
+      "specification" : "HEIF",
+      "summary" : "AVC image and image collection brands",
+      "type" : "avci"
+    },
+    {
+      "name" : "AVC NAL Unit Storage Box",
+      "specification" : "DECE",
+      "summary" : "AVC NAL Unit Storage Box",
+      "type" : "avcn"
+    },
+    {
+      "name" : "Advanced Video Coding Parameters",
+      "specification" : "NALu Video",
+      "summary" : "Advanced Video Coding Parameters (handler: Video, objectType: 0x22)",
+      "type" : "avcp"
+    },
+    {
+      "name" : "AVC Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "AVC image sequence brands",
+      "type" : "avcs"
+    },
+    {
+      "name" : "AVC-based Viewport-dependent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "AVC-based viewport-dependent OMAF video profile",
+      "type" : "avde"
+    },
+    {
+      "name" : "AV1 Image Format Brand",
+      "specification" : "AVIF",
+      "summary" : "AV1 image format brand",
+      "type" : "avif"
+    },
+    {
+      "name" : "AV1 Intra-only Brand",
+      "specification" : "AVIF",
+      "summary" : "AV1 intra-only brand",
+      "type" : "avio"
+    },
+    {
+      "name" : "AV1 Image Sequence Brand",
+      "specification" : "AVIF",
+      "summary" : "AV1 image sequence brand",
+      "type" : "avis"
+    },
+    {
+      "name" : "AVC Layer Description Group",
+      "specification" : "NALu Video",
+      "summary" : "AVC layer description group (category: sample group)",
+      "type" : "avll"
+    },
+    {
+      "name" : "Avid Metadata",
+      "specification" : "Avid",
+      "summary" : "Avid Metadata (category: handler)",
+      "type" : "avmd"
+    },
+    {
+      "name" : "3nd Generation Audio Video Coding Standard Of China",
+      "specification" : "Avs3",
+      "summary" : "3nd Generation Audio Video Coding Standard of China (handler: Video)",
+      "type" : "avs3"
+    },
+    {
+      "name" : "AVC Sub-sequence Group",
+      "specification" : "NALu Video",
+      "summary" : "AVC Sub-sequence group (category: sample group)",
+      "type" : "avss"
+    },
+    {
+      "name" : "2nd Generation Audio Video Coding Standard Of China (AVS Two)",
+      "specification" : "Avs2",
+      "summary" : "2nd Generation Audio Video Coding Standard of China (AVS Two) (handler: Video)",
+      "type" : "avst"
+    },
+    {
+      "name" : "Pre-derived Image Item Base Reference",
+      "specification" : "HEIF",
+      "summary" : "Pre-derived image item base reference (category: item ref.)",
+      "type" : "base"
+    },
+    {
+      "name" : "Blinkbox Master File: H.264 Video And 16-bit Little-endian LPCM Audio",
+      "specification" : "Blinkbox",
+      "summary" : "Blinkbox Master File: H.264 video and 16-bit little-endian LPCM audio",
+      "type" : "bbxm"
+    },
+    {
+      "name" : "Box Index",
+      "specification" : "ISO-Partial",
+      "summary" : "Box Index",
+      "type" : "bidx"
+    },
+    {
+      "name" : "Track Differs In Bitrate",
+      "specification" : "ISO",
+      "summary" : "Track differs in bitrate (category: track sel.)",
+      "type" : "bitr"
+    },
+    {
+      "name" : "Base Location And Purchase Location For License Acquisition",
+      "specification" : "DECE",
+      "summary" : "Base location and purchase location for license acquisition",
+      "type" : "bloc"
+    },
+    {
+      "name" : "Buffer Model Description",
+      "specification" : "JPXS",
+      "summary" : "Buffer Model Description",
+      "type" : "bmdm"
+    },
+    {
+      "name" : "Bits Per Component",
+      "specification" : "JPEG2000",
+      "summary" : "Bits per component",
+      "type" : "bpcc"
+    },
+    {
+      "name" : "Item Brand (type)",
+      "specification" : "ISO",
+      "summary" : "Item brand (type)",
+      "type" : "brnd"
+    },
+    {
+      "name" : "Brotli-compressed Box",
+      "specification" : "JPEG XL",
+      "summary" : "Brotli-compressed box",
+      "type" : "brob"
+    },
+    {
+      "name" : "Burst Image Entity Group",
+      "specification" : "HEIF",
+      "summary" : "Burst image entity group",
+      "type" : "brst"
+    },
+    {
+      "name" : "Bit-rate Information",
+      "specification" : "ISO",
+      "summary" : "Bit-rate information (handler: General)",
+      "type" : "btrt"
+    },
+    {
+      "name" : "Buffering Information",
+      "specification" : "NALu Video",
+      "summary" : "Buffering information",
+      "type" : "buff"
+    },
+    {
+      "name" : "Track Differs By Bandwidth",
+      "specification" : "3GPP",
+      "summary" : "Track differs by bandwidth (category: track sel.)",
+      "type" : "bwas"
+    },
+    {
+      "name" : "Binary XML Container",
+      "specification" : "ISO",
+      "summary" : "binary XML container",
+      "type" : "bxml"
+    },
+    {
+      "name" : "CMAF Media Profile – AVS3-P3",
+      "specification" : "T-AI-109.7",
+      "summary" : "CMAF Media Profile – AVS3-P3",
+      "type" : "ca3a"
+    },
+    {
+      "name" : "CMAF Media Profile - AC-4 Main",
+      "specification" : "ETSI AC-4",
+      "summary" : "CMAF Media Profile - AC-4 Main",
+      "type" : "ca4m"
+    },
+    {
+      "name" : "CMAF Media Profile - AC-4 Single Stream",
+      "specification" : "ETSI AC-4",
+      "summary" : "CMAF Media Profile - AC-4 Single Stream",
+      "type" : "ca4s"
+    },
+    {
+      "name" : "CMAF Media Profile - AAC Adaptive Audio",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AAC Adaptive Audio",
+      "type" : "caaa"
+    },
+    {
+      "name" : "CMAF Media Profile - AAC Core",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AAC Core",
+      "type" : "caac"
+    },
+    {
+      "name" : "CMAF Media Profile For OMAF 3D Audio Baseline Profile",
+      "specification" : "OMAF",
+      "summary" : "CMAF Media Profile for OMAF 3D audio baseline profile",
+      "type" : "cabl"
+    },
+    {
+      "name" : "CMAF Media Profile For ATSC Full Range Constrained Baseline VVC",
+      "specification" : "ATSC 3.0 A345",
+      "summary" : "CMAF Media Profile for ATSC Full Range Constrained Baseline VVC",
+      "type" : "cafr"
+    },
+    {
+      "name" : "CMAF Media Profile - AAC Multichannel Adaptive Audio",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AAC multichannel adaptive audio",
+      "type" : "cama"
+    },
+    {
+      "name" : "CMAF Media Profile - AAC Multichannel Audio",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AAC multichannel audio",
+      "type" : "camc"
+    },
+    {
+      "name" : "Camera Motion Metadata Track",
+      "specification" : "CamMotion",
+      "summary" : "Camera motion metadata track (handler: Video)",
+      "type" : "camm"
+    },
+    {
+      "name" : "Casio Digital Camera",
+      "specification" : "Casio",
+      "summary" : "Casio Digital Camera",
+      "type" : "caqv"
+    },
+    {
+      "name" : "Clean Aperture Sample Grouping",
+      "specification" : "ISO",
+      "summary" : "Clean Aperture Sample Grouping (category: sample group)",
+      "type" : "casg"
+    },
+    {
+      "name" : "CMAF Media Profile - MPEG-D USAC Audio",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - MPEG-D USAC audio",
+      "type" : "casu"
+    },
+    {
+      "name" : "AVS2-P3 Codec",
+      "specification" : "GB-T-20090-9",
+      "summary" : "AVS2-P3 Codec (handler: Audio, objectType: 0xF0)",
+      "type" : "cavs"
+    },
+    {
+      "name" : "AES-CBC Scheme",
+      "specification" : "ISO Common Encryption",
+      "summary" : "AES-CBC scheme (category: protection scheme)",
+      "type" : "cbc1"
+    },
+    {
+      "name" : "AES-CBC Subsample Pattern Encryption Scheme",
+      "specification" : "ISO Common Encryption",
+      "summary" : "AES-CBC subsample pattern encryption scheme (category: protection scheme)",
+      "type" : "cbcs"
+    },
+    {
+      "name" : "CMAF Supplemental Data - CEA-608\/708",
+      "specification" : "CMAF",
+      "summary" : "CMAF Supplemental Data - CEA-608\/708",
+      "type" : "ccea"
+    },
+    {
+      "name" : "Common Container File Format",
+      "specification" : "DECE",
+      "summary" : "Common container file format",
+      "type" : "ccff"
+    },
+    {
+      "name" : "OMA DRM Content ID",
+      "specification" : "OMA DRM 2.1",
+      "summary" : "OMA DRM Content ID",
+      "type" : "ccid"
+    },
+    {
+      "name" : "Content Colour Volume",
+      "specification" : "ISO",
+      "summary" : "Content colour volume (handler: Video)",
+      "type" : "cclv"
+    },
+    {
+      "name" : "Coding Constraints",
+      "specification" : "HEIF",
+      "summary" : "Coding Constraints (handler: Video)",
+      "type" : "ccst"
+    },
+    {
+      "name" : "Track Differs By Codec Type In The Sample Entry",
+      "specification" : "ISO",
+      "summary" : "Track differs by codec type in the Sample Entry (category: track sel.)",
+      "type" : "cdec"
+    },
+    {
+      "name" : "Type And Ordering Of The Components Within The Codestream",
+      "specification" : "JPEG2000",
+      "summary" : "type and ordering of the components within the codestream",
+      "type" : "cdef"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC HDR10 (chd1) With SCTE Dynamic Metadata App #1 (ST2094-10)",
+      "specification" : "SCTE-215-1-1b",
+      "summary" : "CMAF Media Profile - HEVC HDR10 (chd1) with SCTE Dynamic Metadata app #1 (ST2094-10)",
+      "type" : "cdm1"
+    },
+    {
+      "name" : "CMAF Media Profile Compatibility To HDR10+ (ST2094-40)",
+      "specification" : "SCTE-215-1-1b",
+      "summary" : "CMAF Media Profile compatibility to HDR10+ (ST2094-40)",
+      "type" : "cdm4"
+    },
+    {
+      "name" : "Item Describes Referenced Item",
+      "specification" : "HEIF",
+      "summary" : "Item describes referenced item (category: item ref.)",
+      "type" : "cdsc"
+    },
+    {
+      "name" : "This Track Describes The Referenced Tracks And Track Groups Collectively",
+      "specification" : "OMAF",
+      "summary" : "this track describes the referenced tracks and track groups collectively",
+      "type" : "cdtg"
+    },
+    {
+      "name" : "CMAF Media Profile - Enhanced AC-3",
+      "specification" : "ETSI AC-3",
+      "summary" : "CMAF Media Profile - Enhanced AC-3",
+      "type" : "ceac"
+    },
+    {
+      "name" : "AES-CTR Scheme",
+      "specification" : "ISO Common Encryption",
+      "summary" : "AES-CTR scheme (category: protection scheme)",
+      "type" : "cenc"
+    },
+    {
+      "name" : "AES-CTR Subsample Pattern Encryption Scheme",
+      "specification" : "ISO Common Encryption",
+      "summary" : "AES-CTR subsample pattern encryption scheme (category: protection scheme)",
+      "type" : "cens"
+    },
+    {
+      "name" : "CMAF EVC Baseline Media Profile",
+      "specification" : "CMAF",
+      "summary" : "CMAF EVC Baseline Media Profile",
+      "type" : "cevb"
+    },
+    {
+      "name" : "CMAF EVC Main Media Profile",
+      "specification" : "CMAF",
+      "summary" : "CMAF EVC Main Media Profile",
+      "type" : "cevm"
+    },
+    {
+      "name" : "CMAF Media Profile - AVC HD",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AVC HD",
+      "type" : "cfhd"
+    },
+    {
+      "name" : "CMAF Media Profile - AVC SD",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AVC SD",
+      "type" : "cfsd"
+    },
+    {
+      "name" : "The Track Can Be Coarse-grain Scaled.",
+      "specification" : "ISO",
+      "summary" : "The track can be coarse-grain scaled. (category: track sel.)",
+      "type" : "cgsc"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC HDR10",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC HDR10",
+      "type" : "chd1"
+    },
+    {
+      "name" : "CMAF High Frame Rate Media Profile - HEVC HDR10H",
+      "specification" : "CMAF",
+      "summary" : "CMAF High frame rate Media Profile - HEVC HDR10H",
+      "type" : "chd2"
+    },
+    {
+      "name" : "CMAF Media Profile - AVC HDHF",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - AVC HDHF",
+      "type" : "chdf"
+    },
+    {
+      "name" : "CMAF Media Profile For The HEVC-based Viewport-dependent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "CMAF Media Profile for the HEVC-based viewport-dependent OMAF video profile",
+      "type" : "chev"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC HHD10",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC HHD10",
+      "type" : "chh1"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC HHD8",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC HHD8",
+      "type" : "chhd"
+    },
+    {
+      "name" : "Channel Layout",
+      "specification" : "ISO",
+      "summary" : "Channel layout (handler: Audio)",
+      "type" : "chnl"
+    },
+    {
+      "name" : "Complete Track Information",
+      "specification" : "ISO",
+      "summary" : "complete track information",
+      "type" : "cinf"
+    },
+    {
+      "name" : "CMAF Interlaced Media Profile - INT10",
+      "specification" : "CMAF",
+      "summary" : "CMAF Interlaced Media Profile - INT10",
+      "type" : "cint"
+    },
+    {
+      "name" : "Clean Aperture",
+      "specification" : "ISO",
+      "summary" : "Clean aperture (handler: Video)",
+      "type" : "clap"
+    },
+    {
+      "name" : "Closed Caption",
+      "specification" : "Apple",
+      "summary" : "Closed Caption (category: handler)",
+      "type" : "clcp"
+    },
+    {
+      "name" : "Component Reference Level",
+      "specification" : "UNCV",
+      "summary" : "Component Reference Level (handler: Video)",
+      "type" : "clev"
+    },
+    {
+      "name" : "Name Of The Clip File",
+      "specification" : "Apple",
+      "summary" : "Name of the clip file",
+      "type" : "clfn"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC HLG10",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC HLG10",
+      "type" : "clg1"
+    },
+    {
+      "name" : "CMAF High Frame Rate Media Profile - HEVC HLG10H",
+      "specification" : "CMAF",
+      "summary" : "CMAF High frame rate Media Profile - HEVC HLG10H",
+      "type" : "clg2"
+    },
+    {
+      "name" : "Identifier Of The Clip",
+      "specification" : "Apple",
+      "summary" : "Identifier of the clip",
+      "type" : "clid"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "clip"
+    },
+    {
+      "name" : "Content Light Level",
+      "specification" : "ISO",
+      "summary" : "Content Light Level (handler: Video)",
+      "type" : "clli"
+    },
+    {
+      "name" : "Chroma Location",
+      "specification" : "UNCV",
+      "summary" : "Chroma Location (handler: Video)",
+      "type" : "cloc"
+    },
+    {
+      "name" : "Classification Of The Media",
+      "specification" : "3GPP",
+      "summary" : "Classification of the media",
+      "type" : "clsf"
+    },
+    {
+      "name" : "CMAF Media Profile For MPEG-5 LCEVC",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile for MPEG-5 LCEVC",
+      "type" : "clv1"
+    },
+    {
+      "name" : "Mapping Between A Palette And Codestream Components",
+      "specification" : "JPEG2000",
+      "summary" : "mapping between a palette and codestream components",
+      "type" : "cmap"
+    },
+    {
+      "name" : "CMAF Structural Brand",
+      "specification" : "CMAF",
+      "summary" : "CMAF Structural Brand",
+      "type" : "cmf2"
+    },
+    {
+      "name" : "CMAF Structural Brand",
+      "specification" : "CMAF",
+      "summary" : "CMAF Structural Brand",
+      "type" : "cmfc"
+    },
+    {
+      "name" : "CMAF Fragment Format",
+      "specification" : "CMAF",
+      "summary" : "CMAF Fragment Format",
+      "type" : "cmff"
+    },
+    {
+      "name" : "CMAF Chunk Format",
+      "specification" : "CMAF",
+      "summary" : "CMAF Chunk Format",
+      "type" : "cmfl"
+    },
+    {
+      "name" : "CMAF Random Access Chunk",
+      "specification" : "CMAF",
+      "summary" : "CMAF Random Access chunk",
+      "type" : "cmfr"
+    },
+    {
+      "name" : "CMAF Segment Format",
+      "specification" : "CMAF",
+      "summary" : "CMAF Segment Format",
+      "type" : "cmfs"
+    },
+    {
+      "name" : "MPEG-H Audio BL Single-stream Media Profile",
+      "specification" : "CMAF",
+      "summary" : "MPEG-H audio BL single-stream media profile",
+      "type" : "cmh1"
+    },
+    {
+      "name" : "MPEG-H Audio BL Multi-stream Media Profile",
+      "specification" : "CMAF",
+      "summary" : "MPEG-H audio BL multi-stream media profile",
+      "type" : "cmh2"
+    },
+    {
+      "name" : "CMAF Media Profile - MPEG-H 3D Audio LC (mhm2)",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - MPEG-H 3D audio LC (mhm2)",
+      "type" : "cmhm"
+    },
+    {
+      "name" : "CMAF Media Profile - MPEG-H 3D Audio LC (mhm1)",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - MPEG-H 3D audio LC (mhm1)",
+      "type" : "cmhs"
+    },
+    {
+      "name" : "Identifier Of The Camera",
+      "specification" : "Apple",
+      "summary" : "Identifier of the camera",
+      "type" : "cmid"
+    },
+    {
+      "name" : "Name That Identifies The Camera",
+      "specification" : "Apple",
+      "summary" : "Name that identifies the camera",
+      "type" : "cmnm"
+    },
+    {
+      "name" : "Component Definition",
+      "specification" : "UNCV",
+      "summary" : "Component Definition (handler: Video)",
+      "type" : "cmpd"
+    },
+    {
+      "name" : "Dynamic Metadata Sample Entry(XF-AVC S\/XF-HEVC S File Format)",
+      "specification" : "Canon",
+      "summary" : "Dynamic Metadata Sample Entry(XF-AVC S\/XF-HEVC S File Format) (handler: Video)",
+      "type" : "cndm"
+    },
+    {
+      "name" : "64-bit Chunk Offset",
+      "specification" : "ISO",
+      "summary" : "64-bit chunk offset",
+      "type" : "co64"
+    },
+    {
+      "name" : "Composition Information",
+      "specification" : "OMAF",
+      "summary" : "composition information",
+      "type" : "coif"
+    },
+    {
+      "name" : "Content Information Box",
+      "specification" : "DECE",
+      "summary" : "Content Information Box",
+      "type" : "coin"
+    },
+    {
+      "name" : "Name Of The Collection From Which The Media Comes",
+      "specification" : "3GPP",
+      "summary" : "Name of the collection from which the media comes",
+      "type" : "coll"
+    },
+    {
+      "name" : "Color Information (see Note Below)",
+      "specification" : "ISO",
+      "summary" : "Color information (see note below) (handler: Video)",
+      "type" : "colr"
+    },
+    {
+      "name" : "Compressed Boxes",
+      "specification" : "ISO",
+      "summary" : "Compressed boxes",
+      "type" : "comp"
+    },
+    {
+      "name" : "Coverage Information",
+      "specification" : "OMAF",
+      "summary" : "Coverage information",
+      "type" : "covi"
+    },
+    {
+      "name" : "CPCM Auxiliary Metadata",
+      "specification" : "DVB",
+      "summary" : "CPCM Auxiliary Metadata (category: handler)",
+      "type" : "cpad"
+    },
+    {
+      "name" : "Component Palette Configuration",
+      "specification" : "UNCV",
+      "summary" : "Component Palette Configuration (handler: Video)",
+      "type" : "cpal"
+    },
+    {
+      "name" : "Component Pattern Definition",
+      "specification" : "UNCV",
+      "summary" : "Component Pattern Definition (handler: Video)",
+      "type" : "cpat"
+    },
+    {
+      "name" : "CPCM (DVB BlueBook A094) Protected Content",
+      "specification" : "DVB",
+      "summary" : "CPCM (DVB BlueBook A094) protected content (category: protection scheme)",
+      "type" : "cpcm"
+    },
+    {
+      "name" : "Copyright Etc.",
+      "specification" : "ISO",
+      "summary" : "copyright etc.",
+      "type" : "cprt"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "crgn"
+    },
+    {
+      "name" : "Reserved For ClockReferenceStream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for ClockReferenceStream header",
+      "type" : "crhd"
+    },
+    {
+      "name" : "ClockReferenceStream",
+      "specification" : "MP4v2",
+      "summary" : "ClockReferenceStream (category: handler)",
+      "type" : "crsm"
+    },
+    {
+      "name" : "Creation Time Information",
+      "specification" : "HEIF",
+      "summary" : "Creation time information",
+      "type" : "crtt"
+    },
+    {
+      "name" : "Compatible Scheme Type",
+      "specification" : "ISO",
+      "summary" : "Compatible scheme type (category: restricted video scheme)",
+      "type" : "csch"
+    },
+    {
+      "name" : "Compact Sample To Group",
+      "specification" : "ISO",
+      "summary" : "compact sample to group",
+      "type" : "csgp"
+    },
+    {
+      "name" : "CMAF Media Profile - Scalable HEVC Media Profile",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - Scalable HEVC media profile",
+      "type" : "csh1"
+    },
+    {
+      "name" : "Composition To Decode Timeline Mapping",
+      "specification" : "ISO",
+      "summary" : "composition to decode timeline mapping",
+      "type" : "cslg"
+    },
+    {
+      "name" : "Corrected Wall Clock Start Time",
+      "specification" : "ONVIF",
+      "summary" : "corrected wall clock start time",
+      "type" : "cstb"
+    },
+    {
+      "name" : "Complete Subset Track Grouping",
+      "specification" : "NALu Video",
+      "summary" : "complete subset track grouping",
+      "type" : "cstg"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "ctab"
+    },
+    {
+      "name" : "(composition) Time To Sample",
+      "specification" : "ISO",
+      "summary" : "(composition) time to sample",
+      "type" : "ctts"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC UHD10",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC UHD10",
+      "type" : "cud1"
+    },
+    {
+      "name" : "CMAF High Frame Rate Media Profile - HEVC UHD10H",
+      "specification" : "CMAF",
+      "summary" : "CMAF High frame rate Media Profile - HEVC UHD10H",
+      "type" : "cud2"
+    },
+    {
+      "name" : "CMAF Media Profile - HEVC UHD8",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - HEVC UHD8",
+      "type" : "cud8"
+    },
+    {
+      "name" : "CMAF High Frame Rate Media Profile - HEVC UHD8H",
+      "specification" : "CMAF",
+      "summary" : "CMAF High frame rate Media Profile - HEVC UHD8H",
+      "type" : "cud9"
+    },
+    {
+      "name" : "CMAF Media Profile For The Unconstrained HEVC-based Viewport-independent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "CMAF Media Profile for the unconstrained HEVC-based viewport-independent OMAF video profile",
+      "type" : "cuvd"
+    },
+    {
+      "name" : "HDR Vivid Configuration",
+      "specification" : "UWA",
+      "summary" : "HDR Vivid Configuration (handler: Video)",
+      "type" : "cuvv"
+    },
+    {
+      "name" : "AES-CBC-128 Sample Variant",
+      "specification" : "ISO Variants",
+      "summary" : "AES-CBC-128 sample variant (category: protection scheme)",
+      "type" : "cva1"
+    },
+    {
+      "name" : "AES-CTR Sample Variant - Supercedes Cvar",
+      "specification" : "ISO Variants",
+      "summary" : "AES-CTR sample variant - supercedes cvar (category: protection scheme)",
+      "type" : "cva2"
+    },
+    {
+      "name" : "AES-CTR Sample Variant",
+      "specification" : "ISO Variants",
+      "summary" : "AES-CTR sample variant (category: protection scheme)",
+      "type" : "cvar"
+    },
+    {
+      "name" : "CMAF Media Profile For The HEVC-based Viewport-independent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "CMAF Media Profile for the HEVC-based viewport-independent OMAF video profile",
+      "type" : "cvid"
+    },
+    {
+      "name" : "OMA DRM Cover URI",
+      "specification" : "OMA DRM 2.1",
+      "summary" : "OMA DRM Cover URI",
+      "type" : "cvru"
+    },
+    {
+      "name" : "Baseline VVC Media Profile",
+      "specification" : "CMAF",
+      "summary" : "Baseline VVC media profile",
+      "type" : "cvvc"
+    },
+    {
+      "name" : "CMAF Media Profile For Constrained Multilayer VVC",
+      "specification" : "ATSC 3.0 A345",
+      "summary" : "CMAF Media Profile for Constrained Multilayer VVC",
+      "type" : "cvvm"
+    },
+    {
+      "name" : "CMAF Media Profile - WebVTT",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - WebVTT",
+      "type" : "cwvt"
+    },
+    {
+      "name" : "DMB AF Audio With MPEG Layer II Audio, MOT Slide Show, DLS, JPG\/PNG\/MNG Images",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF audio with MPEG Layer II audio, MOT slide show, DLS, JPG\/PNG\/MNG images",
+      "type" : "da0a"
+    },
+    {
+      "name" : "DMB AF, Extending Da0a , With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF, extending da0a , with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "da0b"
+    },
+    {
+      "name" : "DMB AF Audio With ER-BSAC Audio, JPG\/PNG\/MNG Images",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF audio with ER-BSAC audio, JPG\/PNG\/MNG images",
+      "type" : "da1a"
+    },
+    {
+      "name" : "DMB AF, Extending Da1a, With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF, extending da1a, with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "da1b"
+    },
+    {
+      "name" : "DMB AF Audio With HE-AAC V2 Audio, MOT Slide Show, DLS, JPG\/PNG\/MNG Images",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF audio with HE-AAC v2 audio, MOT slide show, DLS, JPG\/PNG\/MNG images",
+      "type" : "da2a"
+    },
+    {
+      "name" : "DMB AF Extending Da2a, With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF extending da2a, with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "da2b"
+    },
+    {
+      "name" : "DMB AF Audio With HE-AAC, JPG\/PNG\/MNG Images",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF audio with HE-AAC, JPG\/PNG\/MNG images",
+      "type" : "da3a"
+    },
+    {
+      "name" : "DMB AF Extending Da3a With BIFS, 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF extending da3a with BIFS, 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "da3b"
+    },
+    {
+      "name" : "Decoder Specific Info For AC-3 Audio",
+      "specification" : "ETSI AC-3",
+      "summary" : "Decoder specific info for AC-3 audio (handler: Audio)",
+      "type" : "dac3"
+    },
+    {
+      "name" : "Decoder Specific Info For AC-4 Audio",
+      "specification" : "ETSI AC-4",
+      "summary" : "Decoder specific info for AC-4 audio (handler: Audio)",
+      "type" : "dac4"
+    },
+    {
+      "name" : "ISO Base Media File Format File Specifically Designed For DASH Including Movie Fragments And Segment Index.",
+      "specification" : "DASH",
+      "summary" : "ISO base media file format file specifically designed for DASH including movie fragments and Segment Index.",
+      "type" : "dash"
+    },
+    {
+      "name" : "Date And Time, Formatted According To ISO 8601, When The Content Was Created. For Clips Captured By Recording Devices, This Is Typically The Date And Time When The Clip’s Recording Started.",
+      "specification" : "Apple",
+      "summary" : "Date and time, formatted according to ISO 8601, when the content was created. For clips captured by recording devices, this is typically the date and time when the clip’s recording started.",
+      "type" : "date"
+    },
+    {
+      "name" : "AV1-related Dolby Vision Consistent With Av01",
+      "specification" : "Dolby Vision",
+      "summary" : "AV1-related Dolby Vision consistent with av01 (handler: Video)",
+      "type" : "dav1"
+    },
+    {
+      "name" : "Dolby Vision Cross-compatible With HDR10",
+      "specification" : "Dolby",
+      "summary" : "Dolby Vision cross-compatible with HDR10",
+      "type" : "db1p"
+    },
+    {
+      "name" : "Dolby Vision Cross-compatible With SDR",
+      "specification" : "Dolby",
+      "summary" : "Dolby Vision cross-compatible with SDR",
+      "type" : "db2g"
+    },
+    {
+      "name" : "Dolby Vision Cross-compatible With HLG (VUI=14)",
+      "specification" : "Dolby",
+      "summary" : "Dolby Vision cross-compatible with HLG (VUI=14)",
+      "type" : "db4g"
+    },
+    {
+      "name" : "Dolby Vision Cross-compatible With HLG (VUI =18)",
+      "specification" : "Dolby",
+      "summary" : "Dolby Vision cross-compatible with HLG (VUI =18)",
+      "type" : "db4h"
+    },
+    {
+      "name" : "MP4 Files With Dolby Content (e.g. Dolby AC-4, Dolby Digital Plus, Dolby TrueHD (Dolby MLP))",
+      "specification" : "Dolby",
+      "summary" : "MP4 files with Dolby content (e.g. Dolby AC-4, Dolby Digital Plus, Dolby TrueHD (Dolby MLP))",
+      "type" : "dby1"
+    },
+    {
+      "name" : "Decoder Configuration For AVS3-P3 Codec",
+      "specification" : "T-AI-109.7",
+      "summary" : "Decoder configuration for AVS3-P3 Codec (handler: Audio)",
+      "type" : "dca3"
+    },
+    {
+      "name" : "VVC Decoding Capability Information",
+      "specification" : "NALu Video",
+      "summary" : "VVC decoding capability information (category: sample group)",
+      "type" : "dcfi"
+    },
+    {
+      "name" : "Decoder Specific Info For Enhanced AC-3 Audio",
+      "specification" : "ETSI AC-3",
+      "summary" : "Decoder specific info for Enhanced AC-3 audio (handler: Audio)",
+      "type" : "dec3"
+    },
+    {
+      "name" : "Track Containing The Depth View",
+      "specification" : "NALu Video",
+      "summary" : "track containing the depth view",
+      "type" : "deps"
+    },
+    {
+      "name" : "Free Lossless Audio Codec (FLAC) Specific Data",
+      "specification" : "FLAC",
+      "summary" : "Free Lossless Audio Codec (FLAC) specific data (handler: Audio)",
+      "type" : "dfLa"
+    },
+    {
+      "name" : "Default HEVC Extractor Constructor Box",
+      "specification" : "NALu Video",
+      "summary" : "Default HEVC extractor constructor box (handler: Video)",
+      "type" : "dhec"
+    },
+    {
+      "name" : "Data Integrity Hash",
+      "specification" : "ISO-Partial",
+      "summary" : "Data Integrity Hash",
+      "type" : "dihd"
+    },
+    {
+      "name" : "Derived Image Item Reference",
+      "specification" : "HEIF",
+      "summary" : "Derived image item reference (category: item ref.)",
+      "type" : "dimg"
+    },
+    {
+      "name" : "Data Information Box, Container",
+      "specification" : "ISO",
+      "summary" : "data information box, container",
+      "type" : "dinf"
+    },
+    {
+      "name" : "Data Integrity",
+      "specification" : "ISO-Partial",
+      "summary" : "Data Integrity",
+      "type" : "dint"
+    },
+    {
+      "name" : "Disparity Information",
+      "specification" : "UNCV",
+      "summary" : "Disparity Information (handler: Video)",
+      "type" : "disi"
+    },
+    {
+      "name" : "DMB AF Supporting All The Components Defined In The Specification",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF supporting all the components defined in the specification",
+      "type" : "dmb1"
+    },
+    {
+      "name" : "DVB Mandatory Metadata",
+      "specification" : "DVB",
+      "summary" : "DVB Mandatory Metadata (category: handler)",
+      "type" : "dmbd"
+    },
+    {
+      "name" : "Downmix Instructions",
+      "specification" : "ISO",
+      "summary" : "Downmix instructions (handler: Audio)",
+      "type" : "dmix"
+    },
+    {
+      "name" : "Decoder Specific Info For MLP Audio",
+      "specification" : "Dolby MLP",
+      "summary" : "Decoder specific info for MLP audio (handler: Audio)",
+      "type" : "dmlp"
+    },
+    {
+      "name" : "Mastering Display Metadata",
+      "specification" : "JPXS",
+      "summary" : "Mastering Display Metadata",
+      "type" : "dmon"
+    },
+    {
+      "name" : "Depth Of Field Bracketing",
+      "specification" : "HEIF",
+      "summary" : "Depth of field bracketing (category: sample group)",
+      "type" : "dobr"
+    },
+    {
+      "name" : "Item Coding Dependency Reference",
+      "specification" : "HEIF",
+      "summary" : "Item coding dependency reference (category: item ref.)",
+      "type" : "dpnd"
+    },
+    {
+      "name" : "DRA Audio",
+      "specification" : "DRA",
+      "summary" : "DRA Audio (handler: Audio, objectType: 0xA7)",
+      "type" : "dra1"
+    },
+    {
+      "name" : "Dirac Video Coder",
+      "specification" : "Dirac",
+      "summary" : "Dirac Video Coder (handler: Video, objectType: 0xA4)",
+      "type" : "drac"
+    },
+    {
+      "name" : "Dependent Random Access Point",
+      "specification" : "ISO",
+      "summary" : "Dependent random access point (category: sample group)",
+      "type" : "drap"
+    },
+    {
+      "name" : "Data Reference Box, Declares Source(s) Of Media Data In Track",
+      "specification" : "ISO",
+      "summary" : "data reference box, declares source(s) of media data in track",
+      "type" : "dref"
+    },
+    {
+      "name" : "Media Description",
+      "specification" : "3GPP",
+      "summary" : "Media description",
+      "type" : "dscp"
+    },
+    {
+      "name" : "DVB Sample Group Description Box",
+      "specification" : "DVB",
+      "summary" : "DVB Sample Group Description Box",
+      "type" : "dsgd"
+    },
+    {
+      "name" : "Media Segment Conforming To The DASH Self-Initializing Media Segment Format Type For ISO Base Media File Format",
+      "specification" : "DASH",
+      "summary" : "Media Segment conforming to the DASH Self-Initializing Media Segment format type for ISO base media file format",
+      "type" : "dsms"
+    },
+    {
+      "name" : "DVB Sample To Group Box",
+      "specification" : "DVB",
+      "summary" : "DVB Sample to Group Box",
+      "type" : "dstg"
+    },
+    {
+      "name" : "SVC Decode Re-timing",
+      "specification" : "NALu Video",
+      "summary" : "SVC decode re-timing (category: sample group)",
+      "type" : "dtrt"
+    },
+    {
+      "name" : "Enhancement Layer For DTS Layered Audio",
+      "specification" : "DTS",
+      "summary" : "Enhancement layer for DTS layered audio (handler: Audio)",
+      "type" : "dts+"
+    },
+    {
+      "name" : "Dependent Base Layer For DTS Layered Audio",
+      "specification" : "DTS",
+      "summary" : "Dependent base layer for DTS layered audio (handler: Audio)",
+      "type" : "dts-"
+    },
+    {
+      "name" : "CMAF Media Profile For Audio Codecs Dtsc Dtsh Or Dtse",
+      "specification" : "DTS-HD",
+      "summary" : "CMAF media profile for audio codecs dtsc dtsh or dtse",
+      "type" : "dts1"
+    },
+    {
+      "name" : "CMAF Media Profile For Audio Codec Dtsx",
+      "specification" : "DTS-UHD",
+      "summary" : "CMAF media profile for audio codec dtsx",
+      "type" : "dts2"
+    },
+    {
+      "name" : "CMAF Media Profile For Audio Codec Dtsy",
+      "specification" : "DTS-UHD",
+      "summary" : "CMAF media profile for audio codec dtsy",
+      "type" : "dts3"
+    },
+    {
+      "name" : "Core Substream",
+      "specification" : "DTS-HD",
+      "summary" : "Core Substream (handler: Audio, objectType: 0xA9)",
+      "type" : "dtsc"
+    },
+    {
+      "name" : "Extension Substream Containing Only LBR",
+      "specification" : "DTS-HD",
+      "summary" : "Extension Substream containing only LBR (handler: Audio, objectType: 0xAC)",
+      "type" : "dtse"
+    },
+    {
+      "name" : "Core Substream + Extension Substream",
+      "specification" : "DTS-HD",
+      "summary" : "Core Substream + Extension Substream (handler: Audio, objectType: 0xAA)",
+      "type" : "dtsh"
+    },
+    {
+      "name" : "Extension Substream Containing Only XLL",
+      "specification" : "DTS-HD",
+      "summary" : "Extension Substream containing only XLL (handler: Audio, objectType: 0xAB)",
+      "type" : "dtsl"
+    },
+    {
+      "name" : "DTS-UHD Profile 2",
+      "specification" : "DTS-UHD",
+      "summary" : "DTS-UHD profile 2 (handler: Audio, objectType: 0xB2)",
+      "type" : "dtsx"
+    },
+    {
+      "name" : "DTS-UHD Profile 3 Or Higher",
+      "specification" : "DTS-UHD",
+      "summary" : "DTS-UHD profile 3 or higher (handler: Audio, objectType: 0xB3)",
+      "type" : "dtsy"
+    },
+    {
+      "name" : "TV-Anytime Metadata, According To DVB Specifications",
+      "specification" : "DVB",
+      "summary" : "TV-Anytime Metadata, according to DVB specifications (category: handler)",
+      "type" : "dtva"
+    },
+    {
+      "name" : "DMB AF Video With AVC Video, ER-BSAC Audio, BIFS, JPG\/PNG\/MNG Images, TS",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF video with AVC video, ER-BSAC audio, BIFS, JPG\/PNG\/MNG images, TS",
+      "type" : "dv1a"
+    },
+    {
+      "name" : "DMB AF, Extending Dv1a, With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF, extending dv1a, with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "dv1b"
+    },
+    {
+      "name" : "DMB AF Video With AVC Video, HE-AACv2 Audio, BIFS, JPG\/PNG\/MNG Images, TS",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF video with AVC video, HE-AACv2 audio, BIFS, JPG\/PNG\/MNG images, TS",
+      "type" : "dv2a"
+    },
+    {
+      "name" : "DMB AF Extending Dv2a, With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF extending dv2a, with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "dv2b"
+    },
+    {
+      "name" : "DMB AF Video With AVC Video, HE-AAC Audio, BIFS, JPG\/PNG\/MNG Images, TS",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF video with AVC video, HE-AAC audio, BIFS, JPG\/PNG\/MNG images, TS",
+      "type" : "dv3a"
+    },
+    {
+      "name" : "DMB AF Extending Dv3a With 3GPP Timed Text, DID, TVA, REL, IPMP",
+      "specification" : "DMB-MAF",
+      "summary" : "DMB AF extending dv3a with 3GPP timed text, DID, TVA, REL, IPMP",
+      "type" : "dv3b"
+    },
+    {
+      "name" : "AVC-based Dolby Vision Derived From Avc1",
+      "specification" : "Dolby Vision",
+      "summary" : "AVC-based Dolby Vision derived from avc1 (handler: Video)",
+      "type" : "dva1"
+    },
+    {
+      "name" : "AVC-based Dolby Vision Derived From Avc3",
+      "specification" : "Dolby Vision",
+      "summary" : "AVC-based Dolby Vision derived from avc3 (handler: Video)",
+      "type" : "dvav"
+    },
+    {
+      "name" : "Dolby Vision Configuration",
+      "specification" : "Dolby Vision",
+      "summary" : "Dolby Vision Configuration (handler: Video)",
+      "type" : "dvcC"
+    },
+    {
+      "name" : "HEVC-based Dolby Vision Derived From Hvc1",
+      "specification" : "Dolby Vision",
+      "summary" : "HEVC-based Dolby Vision derived from hvc1 (handler: Video)",
+      "type" : "dvh1"
+    },
+    {
+      "name" : "HEVC-based Dolby Vision Derived From Hev1",
+      "specification" : "Dolby Vision",
+      "summary" : "HEVC-based Dolby Vision derived from hev1 (handler: Video)",
+      "type" : "dvhe"
+    },
+    {
+      "name" : "Withdrawn, Unused, Do Not Use (was Dolby Vision Metadata)",
+      "specification" : "Deprecated",
+      "summary" : "withdrawn, unused, do not use (was Dolby Vision Metadata) (category: handler)",
+      "type" : "dvmd"
+    },
+    {
+      "name" : "DVB RTP",
+      "specification" : "DVB",
+      "summary" : "DVB RTP",
+      "type" : "dvr1"
+    },
+    {
+      "name" : "DVB Transport Stream",
+      "specification" : "DVB",
+      "summary" : "DVB Transport Stream",
+      "type" : "dvt1"
+    },
+    {
+      "name" : "Dolby Vision Extended Configuration",
+      "specification" : "Dolby Vision",
+      "summary" : "Dolby Vision Extended Configuration (handler: Video)",
+      "type" : "dvvC"
+    },
+    {
+      "name" : "Dolby Vision Extended Configuration 2",
+      "specification" : "Dolby Vision",
+      "summary" : "Dolby Vision Extended Configuration 2 (handler: Video)",
+      "type" : "dvwC"
+    },
+    {
+      "name" : "DxO ONE Camera",
+      "specification" : "DxO",
+      "summary" : "DxO ONE camera",
+      "type" : "dxo "
+    },
+    {
+      "name" : "Dynamic Overlay Parameters",
+      "specification" : "OMAF",
+      "summary" : "Dynamic overlay parameters (handler: Metadata)",
+      "type" : "dyol"
+    },
+    {
+      "name" : "Dynamic Spatial Region Data",
+      "specification" : "V3C-SYS",
+      "summary" : "Dynamic spatial region data (handler: Volumetric visual media)",
+      "type" : "dyvm"
+    },
+    {
+      "name" : "Dynamic Viewpoint Parameters",
+      "specification" : "OMAF",
+      "summary" : "Dynamic viewpoint parameters (handler: Metadata)",
+      "type" : "dyvp"
+    },
+    {
+      "name" : "Withdrawn, Unused, Do Not Use (was Enhanced AC-3 Audio With JOC)",
+      "specification" : "Deprecated",
+      "summary" : "withdrawn, unused, do not use (was enhanced AC-3 audio with JOC) (handler: Audio)",
+      "type" : "ec+3"
+    },
+    {
+      "name" : "Enhanced AC-3 Audio",
+      "specification" : "ETSI AC-3",
+      "summary" : "Enhanced AC-3 audio (handler: Audio, objectType: 0xA6)",
+      "type" : "ec-3"
+    },
+    {
+      "name" : "Extrinsic Camera Parameters",
+      "specification" : "NALu Video",
+      "summary" : "Extrinsic camera parameters (handler: Video)",
+      "type" : "ecam"
+    },
+    {
+      "name" : "Like 'ercm' But Overlays May Additionally Be Present",
+      "specification" : "OMAF",
+      "summary" : "Like 'ercm' but overlays may additionally be present (category: restricted video scheme)",
+      "type" : "ecov"
+    },
+    {
+      "name" : "EDRAP Sample Group",
+      "specification" : "ISO",
+      "summary" : "EDRAP sample group (category: sample group)",
+      "type" : "edrp"
+    },
+    {
+      "name" : "Edit List Container",
+      "specification" : "ISO",
+      "summary" : "edit list container",
+      "type" : "edts"
+    },
+    {
+      "name" : "Extended Language Tag",
+      "specification" : "ISO",
+      "summary" : "Extended Language Tag",
+      "type" : "elng"
+    },
+    {
+      "name" : "An Edit List",
+      "specification" : "ISO",
+      "summary" : "an edit list",
+      "type" : "elst"
+    },
+    {
+      "name" : "Elliptical View Array",
+      "specification" : "NALu Video",
+      "summary" : "Elliptical view array (category: Multiview Reln. Attribute)",
+      "type" : "elvi"
+    },
+    {
+      "name" : "Event Message Box Present",
+      "specification" : "DASH",
+      "summary" : "Event message box present",
+      "type" : "emsg"
+    },
+    {
+      "name" : "Encrypted\/protected Volumetric Visual",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/protected volumetric visual (handler: Volumetric visual media)",
+      "type" : "enc3"
+    },
+    {
+      "name" : "Encrypted\/Protected Audio",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/Protected audio (handler: Audio)",
+      "type" : "enca"
+    },
+    {
+      "name" : "Encrypted\/Protected Font",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/Protected font (handler: Font)",
+      "type" : "encf"
+    },
+    {
+      "name" : "Encrypted\/Protected Metadata",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/Protected metadata (handler: Metadata)",
+      "type" : "encm"
+    },
+    {
+      "name" : "Encrypted\/protected Haptics",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/protected haptics (handler: Haptics)",
+      "type" : "encp"
+    },
+    {
+      "name" : "Encrypted Systems Stream",
+      "specification" : "ISO",
+      "summary" : "Encrypted Systems stream (handler: (various))",
+      "type" : "encs"
+    },
+    {
+      "name" : "Encrypted Text",
+      "specification" : "ISO",
+      "summary" : "Encrypted Text (handler: Text)",
+      "type" : "enct"
+    },
+    {
+      "name" : "Encrypted\/protected Subtitles",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/protected subtitles (handler: Subtitles)",
+      "type" : "encu"
+    },
+    {
+      "name" : "Encrypted\/protected Video",
+      "specification" : "ISO",
+      "summary" : "Encrypted\/protected video (handler: Video)",
+      "type" : "encv"
+    },
+    {
+      "name" : "End Of Bitstream",
+      "specification" : "NALu Video",
+      "summary" : "End of bitstream (category: sample group)",
+      "type" : "eob "
+    },
+    {
+      "name" : "End Of Sequence",
+      "specification" : "NALu Video",
+      "summary" : "End of sequence (category: sample group)",
+      "type" : "eos "
+    },
+    {
+      "name" : "Playout Entity Grouping",
+      "specification" : "V3C-SYS",
+      "summary" : "playout entity grouping",
+      "type" : "eply"
+    },
+    {
+      "name" : "Equivalent Samples",
+      "specification" : "HEIF",
+      "summary" : "equivalent samples (category: sample group)",
+      "type" : "eqiv"
+    },
+    {
+      "name" : "Equirectangular Or Cubemap Projected Video With Derived Region-wise Packing",
+      "specification" : "OMAF",
+      "summary" : "Equirectangular or cubemap projected video with derived region-wise packing (category: restricted video scheme)",
+      "type" : "erc2"
+    },
+    {
+      "name" : "Equirectangular Or Cubemap Projected Video With Indicated Region-wise Packing",
+      "specification" : "OMAF",
+      "summary" : "Equirectangular or cubemap projected video with indicated region-wise packing (category: restricted video scheme)",
+      "type" : "ercm"
+    },
+    {
+      "name" : "Region Reference",
+      "specification" : "HEIF",
+      "summary" : "Region reference (category: item ref.)",
+      "type" : "eroi"
+    },
+    {
+      "name" : "Equirectangular Projected Video (essentially Without Region-wise Packing)",
+      "specification" : "OMAF",
+      "summary" : "Equirectangular projected video (essentially without region-wise packing) (category: restricted video scheme)",
+      "type" : "erpv"
+    },
+    {
+      "name" : "Elementary Stream Descriptor",
+      "specification" : "MP4v2",
+      "summary" : "Elementary stream descriptor (handler: General)",
+      "type" : "esds"
+    },
+    {
+      "name" : "Essential Descriptions Hierarchy Sample Grouping",
+      "specification" : "ISO",
+      "summary" : "Essential descriptions hierarchy sample grouping (category: sample group)",
+      "type" : "esgh"
+    },
+    {
+      "name" : "Essential Sample Group Samples",
+      "specification" : "ISO",
+      "summary" : "Essential sample group samples (category: restricted scheme)",
+      "type" : "essg"
+    },
+    {
+      "name" : "Extended Type And Type Combination",
+      "specification" : "ISO",
+      "summary" : "extended type and type combination",
+      "type" : "etyp"
+    },
+    {
+      "name" : "EVC Baseline Coded Image",
+      "specification" : "HEIF",
+      "summary" : "EVC Baseline coded image",
+      "type" : "evbi"
+    },
+    {
+      "name" : "EVC Baseline Coded Image Sequence",
+      "specification" : "HEIF",
+      "summary" : "EVC Baseline coded image sequence",
+      "type" : "evbs"
+    },
+    {
+      "name" : "Essential Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Essential Video Coding (handler: Video)",
+      "type" : "evc1"
+    },
+    {
+      "name" : "EVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "EVC configuration (handler: Video)",
+      "type" : "evcC"
+    },
+    {
+      "name" : "EVC Slice Base Track",
+      "specification" : "NALu Video",
+      "summary" : "EVC slice base track",
+      "type" : "evcr"
+    },
+    {
+      "name" : "EVC Slice Reference",
+      "specification" : "HEIF",
+      "summary" : "EVC slice reference (category: item ref.)",
+      "type" : "evir"
+    },
+    {
+      "name" : "Essential Video Coding Slice Base Track",
+      "specification" : "NALu Video",
+      "summary" : "Essential Video Coding slice base track (handler: Video)",
+      "type" : "evm1"
+    },
+    {
+      "name" : "EVC Main Coded Image",
+      "specification" : "HEIF",
+      "summary" : "EVC Main coded image",
+      "type" : "evmi"
+    },
+    {
+      "name" : "EVC Main Coded Image Sequenc",
+      "specification" : "HEIF",
+      "summary" : "EVC Main coded image sequenc",
+      "type" : "evms"
+    },
+    {
+      "name" : "Essential Video Coding Slice Component Track Without Parameter Sets",
+      "specification" : "NALu Video",
+      "summary" : "Essential Video Coding slice component track without parameter sets (handler: Video)",
+      "type" : "evs1"
+    },
+    {
+      "name" : "Essential Video Coding Slice Component Track That May Contain Parameter Sets",
+      "specification" : "NALu Video",
+      "summary" : "Essential Video Coding slice component track that may contain parameter sets (handler: Video)",
+      "type" : "evs2"
+    },
+    {
+      "name" : "Configuration For EVC Slice Component Track",
+      "specification" : "NALu Video",
+      "summary" : "Configuration for EVC slice component track (handler: Video)",
+      "type" : "evsC"
+    },
+    {
+      "name" : "Event Message Instance",
+      "specification" : "Event Message",
+      "summary" : "Event message instance (handler: Metadata)",
+      "type" : "evte"
+    },
+    {
+      "name" : "Event Information",
+      "specification" : "ATSC 3.0 A337",
+      "summary" : "Event information",
+      "type" : "evti"
+    },
+    {
+      "name" : "Scalable Image Item Reference",
+      "specification" : "HEIF",
+      "summary" : "Scalable image item reference (category: item ref.)",
+      "type" : "exbl"
+    },
+    {
+      "name" : "Free Lossless Audio Codec (FLAC)",
+      "specification" : "FLAC",
+      "summary" : "Free Lossless Audio Codec (FLAC) (handler: Audio)",
+      "type" : "fLaC"
+    },
+    {
+      "name" : "Fade Transition Effect",
+      "specification" : "HEIF",
+      "summary" : "Fade transition effect",
+      "type" : "fade"
+    },
+    {
+      "name" : "Favorites Collection Entity Group",
+      "specification" : "HEIF",
+      "summary" : "Favorites Collection entity group",
+      "type" : "favc"
+    },
+    {
+      "name" : "File Delivery Reference",
+      "specification" : "ISO",
+      "summary" : "File delivery reference (category: item ref.)",
+      "type" : "fdel"
+    },
+    {
+      "name" : "File Delivery Hints",
+      "specification" : "ISO",
+      "summary" : "File delivery hints (handler: Hint)",
+      "type" : "fdp "
+    },
+    {
+      "name" : "Font",
+      "specification" : "ISO",
+      "summary" : "Font (category: handler)",
+      "type" : "fdsm"
+    },
+    {
+      "name" : "FEC Informatiom",
+      "specification" : "ISO",
+      "summary" : "FEC Informatiom",
+      "type" : "feci"
+    },
+    {
+      "name" : "FEC Reservoir",
+      "specification" : "ISO",
+      "summary" : "FEC Reservoir",
+      "type" : "fecr"
+    },
+    {
+      "name" : "The Track Can Be Fine-grain Scaled.",
+      "specification" : "ISO",
+      "summary" : "The track can be fine-grain scaled. (category: track sel.)",
+      "type" : "fgsc"
+    },
+    {
+      "name" : "Box File Index",
+      "specification" : "ISO-Partial",
+      "summary" : "Box File Index",
+      "type" : "fidx"
+    },
+    {
+      "name" : "Field Coding",
+      "specification" : "MJ2",
+      "summary" : "Field Coding (handler: Video)",
+      "type" : "fiel"
+    },
+    {
+      "name" : "FD Item Information",
+      "specification" : "ISO",
+      "summary" : "FD Item Information",
+      "type" : "fiin"
+    },
+    {
+      "name" : "File Reservoir",
+      "specification" : "ISO",
+      "summary" : "File Reservoir",
+      "type" : "fire"
+    },
+    {
+      "name" : "Focus Bracketing Exposure Bracketing",
+      "specification" : "HEIF",
+      "summary" : "Focus bracketing exposure bracketing (category: sample group)",
+      "type" : "fobr"
+    },
+    {
+      "name" : "Open-ended Scheme Type For Fisheye Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "Open-ended scheme type for fisheye omnidirectional video (category: restricted video scheme)",
+      "type" : "fodv"
+    },
+    {
+      "name" : "Font Item Reference",
+      "specification" : "ISO",
+      "summary" : "Font item reference (category: item ref.)",
+      "type" : "font"
+    },
+    {
+      "name" : "Fisheye Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "fisheye omnidirectional video",
+      "type" : "fovd"
+    },
+    {
+      "name" : "Essential Fisheye Information",
+      "specification" : "OMAF",
+      "summary" : "Essential fisheye information",
+      "type" : "fovi"
+    },
+    {
+      "name" : "Frame Packing Information",
+      "specification" : "UNCV",
+      "summary" : "Frame Packing Information (handler: Video)",
+      "type" : "fpac"
+    },
+    {
+      "name" : "File Partition",
+      "specification" : "ISO",
+      "summary" : "File Partition",
+      "type" : "fpar"
+    },
+    {
+      "name" : "Floating-point Based PCM Format For Audio",
+      "specification" : "ISO-UNCA",
+      "summary" : "Floating-point based PCM format for audio (handler: Audio)",
+      "type" : "fpcm"
+    },
+    {
+      "name" : "Track Differs In Frame Rate",
+      "specification" : "ISO",
+      "summary" : "Track differs in frame rate (category: track sel.)",
+      "type" : "frar"
+    },
+    {
+      "name" : "Free Space",
+      "specification" : "ISO",
+      "summary" : "free space",
+      "type" : "free"
+    },
+    {
+      "name" : "Original Format Box",
+      "specification" : "ISO",
+      "summary" : "original format box",
+      "type" : "frma"
+    },
+    {
+      "name" : "Front Part",
+      "specification" : "ISO-Partial",
+      "summary" : "Front Part",
+      "type" : "frpa"
+    },
+    {
+      "name" : "File Type And Compatibility",
+      "specification" : "ISO\/IEC 14496-12",
+      "summary" : "Identifies the file type and compatibility brands for the bitstream.",
+      "type" : "ftyp"
+    },
+    {
+      "name" : "Supplemental Fisheye Information",
+      "specification" : "OMAF",
+      "summary" : "Supplemental fisheye information",
+      "type" : "fvsi"
+    },
+    {
+      "name" : "ITU-T Recommendation G.719 (2008)",
+      "specification" : "ITU G.719",
+      "summary" : "ITU-T Recommendation G.719 (2008) (handler: Audio, objectType: 0xA8)",
+      "type" : "g719"
+    },
+    {
+      "name" : "ITU-T Recommendation G.726 (1990)",
+      "specification" : "SDV",
+      "summary" : "ITU-T Recommendation G.726 (1990) (handler: Audio)",
+      "type" : "g726"
+    },
+    {
+      "name" : "Geometry",
+      "specification" : "NALu Video",
+      "summary" : "Geometry (category: Multiview Reln. Attribute)",
+      "type" : "geom"
+    },
+    {
+      "name" : "General MPEG-4 Systems Streams (without Specific Handler)",
+      "specification" : "see (1) below",
+      "summary" : "General MPEG-4 systems streams (without specific handler) (category: handler)",
+      "type" : "gesm"
+    },
+    {
+      "name" : "Group ID To Name",
+      "specification" : "ISO",
+      "summary" : "Group ID to name",
+      "type" : "gitn"
+    },
+    {
+      "name" : "Media Genre",
+      "specification" : "3GPP",
+      "summary" : "Media genre",
+      "type" : "gnre"
+    },
+    {
+      "name" : "Image Item Grid Derivation",
+      "specification" : "HEIF",
+      "summary" : "Image item grid derivation",
+      "type" : "grid"
+    },
+    {
+      "name" : "OMA DRM Group ID",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Group ID",
+      "type" : "grpi"
+    },
+    {
+      "name" : "Groups List Box",
+      "specification" : "ISO",
+      "summary" : "Groups list box",
+      "type" : "grpl"
+    },
+    {
+      "name" : "Haptics",
+      "specification" : "ISO",
+      "summary" : "Haptics (category: handler)",
+      "type" : "hapt"
+    },
+    {
+      "name" : "Handler Property That Provides A Mapping Of A Media Handler With An Item In A MetaBox",
+      "specification" : "ISO",
+      "summary" : "Handler property that provides a mapping of a media handler with an item in a MetaBox",
+      "type" : "hdlp"
+    },
+    {
+      "name" : "Handler, Declares The Media (handler) Type",
+      "specification" : "ISO",
+      "summary" : "handler, declares the media (handler) type",
+      "type" : "hdlr"
+    },
+    {
+      "name" : "HEVC Image And Image Collection Brands",
+      "specification" : "HEIF",
+      "summary" : "HEVC image and image collection brands",
+      "type" : "heic"
+    },
+    {
+      "name" : "L-HEVC Image And Image Collection Brands",
+      "specification" : "HEIF",
+      "summary" : "L-HEVC image and image collection brands",
+      "type" : "heim"
+    },
+    {
+      "name" : "L-HEVC Image And Image Collection Brands",
+      "specification" : "HEIF",
+      "summary" : "L-HEVC image and image collection brands",
+      "type" : "heis"
+    },
+    {
+      "name" : "HEVC Image And Image Collection Brands",
+      "specification" : "HEIF",
+      "summary" : "HEVC image and image collection brands",
+      "type" : "heix"
+    },
+    {
+      "name" : "OMAF HEVC Image Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF HEVC image profile",
+      "type" : "heoi"
+    },
+    {
+      "name" : "HEVC Video With Parameter Sets In The Sample Entry Or Samples",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with parameter sets in the Sample Entry or samples (handler: Video, objectType: 0x23)",
+      "type" : "hev1"
+    },
+    {
+      "name" : "HEVC Video With Constrained Extractors And\/or Aggregators And Parameter Sets In The Sample Entry Or Samples",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with constrained extractors and\/or aggregators and parameter sets in the Sample Entry or samples (handler: Video, objectType: 0x23)",
+      "type" : "hev2"
+    },
+    {
+      "name" : "HEVC Video With Extractors And\/or Aggregators And Parameter Sets In The Sample Entry Or Samples",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with extractors and\/or aggregators and parameter sets in the Sample Entry or samples (handler: Video, objectType: 0x23)",
+      "type" : "hev3"
+    },
+    {
+      "name" : "HEVC Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "HEVC image sequence brands",
+      "type" : "hevc"
+    },
+    {
+      "name" : "HEVC-based Viewport-dependent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "HEVC-based viewport-dependent OMAF video profile",
+      "type" : "hevd"
+    },
+    {
+      "name" : "HEVC-based Viewport-independent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "HEVC-based viewport-independent OMAF video profile",
+      "type" : "hevi"
+    },
+    {
+      "name" : "L-HEVC Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "L-HEVC image sequence brands",
+      "type" : "hevm"
+    },
+    {
+      "name" : "L-HEVC Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "L-HEVC image sequence brands",
+      "type" : "hevs"
+    },
+    {
+      "name" : "HEVC Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "HEVC image sequence brands",
+      "type" : "hevx"
+    },
+    {
+      "name" : "Hint Dependency",
+      "specification" : "ISO",
+      "summary" : "Hint dependency",
+      "type" : "hind"
+    },
+    {
+      "name" : "Hint Information",
+      "specification" : "ISO",
+      "summary" : "hint information",
+      "type" : "hinf"
+    },
+    {
+      "name" : "Hint",
+      "specification" : "ISO",
+      "summary" : "Hint (category: handler)",
+      "type" : "hint"
+    },
+    {
+      "name" : "Hint Media Header, Overall Information (hint Track Only)",
+      "specification" : "ISO",
+      "summary" : "hint media header, overall information (hint track only)",
+      "type" : "hmhd"
+    },
+    {
+      "name" : "Hint Information",
+      "specification" : "ISO",
+      "summary" : "Hint information",
+      "type" : "hnti"
+    },
+    {
+      "name" : "Hipix Rich Picture Format",
+      "specification" : "Hipix",
+      "summary" : "Hipix Rich Picture Format (category: handler)",
+      "type" : "hpix"
+    },
+    {
+      "name" : "HEVC Video With Parameter Sets Only In The Sample Entry",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with parameter sets only in the Sample Entry (handler: Video, objectType: 0x23)",
+      "type" : "hvc1"
+    },
+    {
+      "name" : "HEVC Video With Constrained Extractors And\/or Aggregators And Parameter Sets Only In The Sample Entry",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with constrained extractors and\/or aggregators and parameter sets only in the Sample Entry (handler: Video, objectType: 0x23)",
+      "type" : "hvc2"
+    },
+    {
+      "name" : "HEVC Video With Extractors And\/or Aggregators And Parameter Sets Only In The Sample Entry",
+      "specification" : "NALu Video",
+      "summary" : "HEVC video with extractors and\/or aggregators and parameter sets only in the Sample Entry (handler: Video, objectType: 0x23)",
+      "type" : "hvc3"
+    },
+    {
+      "name" : "HEVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "HEVC Configuration (handler: Video)",
+      "type" : "hvcC"
+    },
+    {
+      "name" : "L-HEVC Explicit Reconstruction",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC explicit reconstruction",
+      "type" : "hvce"
+    },
+    {
+      "name" : "L-HEVC Implicit Reconstruction",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC implicit reconstruction",
+      "type" : "hvci"
+    },
+    {
+      "name" : "L-HEVC Extended Explicit Reconstruction Brand",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC extended explicit reconstruction brand",
+      "type" : "hvcx"
+    },
+    {
+      "name" : "HEVC Tile Tracks",
+      "specification" : "NALu Video",
+      "summary" : "HEVC tile tracks (handler: Video)",
+      "type" : "hvt1"
+    },
+    {
+      "name" : "HEVC Slice Segment Data Track",
+      "specification" : "NALu Video",
+      "summary" : "HEVC slice segment data track (handler: Video)",
+      "type" : "hvt2"
+    },
+    {
+      "name" : "HEVC Tile Track With Slice Segment Header Info",
+      "specification" : "NALu Video",
+      "summary" : "HEVC Tile Track with Slice Segment Header Info (handler: Video)",
+      "type" : "hvt3"
+    },
+    {
+      "name" : "HEVC Tile Configuration",
+      "specification" : "NALu Video",
+      "summary" : "HEVC Tile Configuration (handler: Video)",
+      "type" : "hvtC"
+    },
+    {
+      "name" : "HEVC Tile Track",
+      "specification" : "NALu Video",
+      "summary" : "HEVC Tile Track",
+      "type" : "hvti"
+    },
+    {
+      "name" : "YUV 420 8 Bits Planar Y Cb Cr",
+      "specification" : "UNCV",
+      "summary" : "YUV 420 8 bits planar Y Cb Cr",
+      "type" : "i420"
+    },
+    {
+      "name" : "Immersive Audio Model And Formats - Encapsulated IA Sequence",
+      "specification" : "AOM-IAMF",
+      "summary" : "Immersive Audio Model and Formats - Encapsulated IA Sequence (handler: Audio)",
+      "type" : "iamf"
+    },
+    {
+      "name" : "Image Item With An Audio Track",
+      "specification" : "HEIF",
+      "summary" : "Image item with an audio track",
+      "type" : "iaug"
+    },
+    {
+      "name" : "Item Auxiliary Information",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Item Auxiliary Information",
+      "type" : "iaux"
+    },
+    {
+      "name" : "Intrinsic Camera Parameters",
+      "specification" : "NALu Video",
+      "summary" : "Intrinsic camera parameters (handler: Video)",
+      "type" : "icam"
+    },
+    {
+      "name" : "OMA DRM Icon URI",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Icon URI",
+      "type" : "icnu"
+    },
+    {
+      "name" : "Incomplete Volumetric Visual",
+      "specification" : "ISO",
+      "summary" : "Incomplete volumetric visual (handler: Volumetric visual media)",
+      "type" : "icp3"
+    },
+    {
+      "name" : "Incomplete Audio",
+      "specification" : "ISO",
+      "summary" : "Incomplete audio (handler: Audio)",
+      "type" : "icpa"
+    },
+    {
+      "name" : "Incomplete Hint",
+      "specification" : "ISO",
+      "summary" : "Incomplete hint (handler: Hint)",
+      "type" : "icph"
+    },
+    {
+      "name" : "Incomplete Timed Metadata",
+      "specification" : "ISO",
+      "summary" : "Incomplete timed metadata (handler: Metadata)",
+      "type" : "icpm"
+    },
+    {
+      "name" : "Incomplete Haptics",
+      "specification" : "ISO",
+      "summary" : "Incomplete haptics (handler: Haptics)",
+      "type" : "icpp"
+    },
+    {
+      "name" : "Incomplete System",
+      "specification" : "ISO",
+      "summary" : "Incomplete system (handler: (various))",
+      "type" : "icps"
+    },
+    {
+      "name" : "Incomplete Text",
+      "specification" : "ISO",
+      "summary" : "Incomplete text (handler: Text)",
+      "type" : "icpt"
+    },
+    {
+      "name" : "Incomplete Video",
+      "specification" : "ISO",
+      "summary" : "Incomplete video (handler: Video)",
+      "type" : "icpv"
+    },
+    {
+      "name" : "Item Data",
+      "specification" : "ISO",
+      "summary" : "Item data",
+      "type" : "idat"
+    },
+    {
+      "name" : "Image Item Identity Derivation",
+      "specification" : "HEIF",
+      "summary" : "Image item identity derivation",
+      "type" : "iden"
+    },
+    {
+      "name" : "Item Encryption",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Item Encryption",
+      "type" : "ienc"
+    },
+    {
+      "name" : "The IFE-AAC Core Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AAC Core Media Profile",
+      "type" : "ifaa"
+    },
+    {
+      "name" : "The IFE-AV1-HD Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AV1-HD Media Profile",
+      "type" : "ifah"
+    },
+    {
+      "name" : "The IFE-AV1-HDHDR Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AV1-HDHDR Media Profile",
+      "type" : "ifai"
+    },
+    {
+      "name" : "The IFE-AV1-SD Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AV1-SD Media Profile",
+      "type" : "ifas"
+    },
+    {
+      "name" : "The IFE-AV1-UHD10 Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AV1-UHD10 Media Profile",
+      "type" : "ifau"
+    },
+    {
+      "name" : "The IFE-AV1-HDR10 Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-AV1-HDR10 Media Profile",
+      "type" : "ifav"
+    },
+    {
+      "name" : "The IFE-HD Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-HD Media Profile",
+      "type" : "ifhd"
+    },
+    {
+      "name" : "The IFE-HDHDR Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-HDHDR Media Profile",
+      "type" : "ifhh"
+    },
+    {
+      "name" : "The IFE-HDR10 Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-HDR10 Media Profile",
+      "type" : "ifhr"
+    },
+    {
+      "name" : "The IFE-HSD Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-HSD Media Profile",
+      "type" : "ifhs"
+    },
+    {
+      "name" : "The IFE-UHD10 Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-UHD10 Media Profile",
+      "type" : "ifhu"
+    },
+    {
+      "name" : "The IFE-HHD10 Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-HHD10 Media Profile",
+      "type" : "ifhx"
+    },
+    {
+      "name" : "Apple IFrame Specification, Version 8.1 Jan 2013",
+      "specification" : "Apple",
+      "summary" : "Apple iFrame Specification, Version 8.1 Jan 2013",
+      "type" : "ifrm"
+    },
+    {
+      "name" : "The IFE-SD Media Profile",
+      "specification" : "IFE",
+      "summary" : "The IFE-SD Media Profile",
+      "type" : "ifsd"
+    },
+    {
+      "name" : "Image Header",
+      "specification" : "JPEG2000",
+      "summary" : "Image Header",
+      "type" : "ihdr"
+    },
+    {
+      "name" : "Item Information",
+      "specification" : "ISO",
+      "summary" : "item information",
+      "type" : "iinf"
+    },
+    {
+      "name" : "Initial Viewing Orientation",
+      "specification" : "OMAF",
+      "summary" : "Initial viewing orientation",
+      "type" : "iivo"
+    },
+    {
+      "name" : "Field Interlace Type",
+      "specification" : "UNCV",
+      "summary" : "Field Interlace Type (category: sample group)",
+      "type" : "ilce"
+    },
+    {
+      "name" : "Field Interlace Property",
+      "specification" : "UNCV",
+      "summary" : "Field Interlace Property",
+      "type" : "ilcp"
+    },
+    {
+      "name" : "Item Data Location",
+      "specification" : "ISO",
+      "summary" : "Item data location (category: item ref.)",
+      "type" : "iloc"
+    },
+    {
+      "name" : "Inline View Array",
+      "specification" : "NALu Video",
+      "summary" : "Inline view array (category: Multiview Reln. Attribute)",
+      "type" : "ilvi"
+    },
+    {
+      "name" : "CMAF Media Profile - IMSC1 Image",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - IMSC1 Image",
+      "type" : "im1i"
+    },
+    {
+      "name" : "CMAF Media Profile - IMSC1 Text",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - IMSC1 Text",
+      "type" : "im1t"
+    },
+    {
+      "name" : "CMAF Media Profile - IMSC1.1 Image",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - IMSC1.1 Image",
+      "type" : "im2i"
+    },
+    {
+      "name" : "CMAF Media Profile - IMSC1.1 Text",
+      "specification" : "CMAF",
+      "summary" : "CMAF Media Profile - IMSC1.1 Text",
+      "type" : "im2t"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "imap"
+    },
+    {
+      "name" : "Identified Media Data",
+      "specification" : "ISO",
+      "summary" : "Identified media data",
+      "type" : "imda"
+    },
+    {
+      "name" : "Identified Media Data",
+      "specification" : "ISO",
+      "summary" : "identified media data (category: Data reference)",
+      "type" : "imdt"
+    },
+    {
+      "name" : "IPMP Information Box",
+      "specification" : "ISO",
+      "summary" : "IPMP Information box",
+      "type" : "imif"
+    },
+    {
+      "name" : "Image Mirroring",
+      "specification" : "HEIF",
+      "summary" : "Image mirroring",
+      "type" : "imir"
+    },
+    {
+      "name" : "Item Information Entry",
+      "specification" : "ISO",
+      "summary" : "Item information entry",
+      "type" : "infe"
+    },
+    {
+      "name" : "OMA DRM Info URL",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Info URL",
+      "type" : "infu"
+    },
+    {
+      "name" : "Initial Viewing Orientation",
+      "specification" : "OMAF",
+      "summary" : "Initial viewing orientation (handler: Metadata)",
+      "type" : "invo"
+    },
+    {
+      "name" : "Initial Viewpoint",
+      "specification" : "OMAF",
+      "summary" : "Initial viewpoint (handler: Metadata)",
+      "type" : "invp"
+    },
+    {
+      "name" : "Object Descriptor Container Box",
+      "specification" : "MP4v2",
+      "summary" : "Object Descriptor container box",
+      "type" : "iods"
+    },
+    {
+      "name" : "Image Item Overlay Derivation",
+      "specification" : "HEIF",
+      "summary" : "Image item overlay derivation",
+      "type" : "iovl"
+    },
+    {
+      "name" : "Integer Based PCM Format For Audio",
+      "specification" : "ISO-UNCA",
+      "summary" : "Integer based PCM format for audio (handler: Audio)",
+      "type" : "ipcm"
+    },
+    {
+      "name" : "ItemPropertyContainerBox",
+      "specification" : "ISO",
+      "summary" : "ItemPropertyContainerBox",
+      "type" : "ipco"
+    },
+    {
+      "name" : "DVB IPDC ESG Metadata",
+      "specification" : "DVB",
+      "summary" : "DVB IPDC ESG Metadata (category: handler)",
+      "type" : "ipdc"
+    },
+    {
+      "name" : "Reserved For IPMP Stream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for IPMP Stream header",
+      "type" : "iphd"
+    },
+    {
+      "name" : "This Track Contains IPI Declarations For The Referenced Track",
+      "specification" : "MP4v2",
+      "summary" : "this track contains IPI declarations for the referenced track",
+      "type" : "ipir"
+    },
+    {
+      "name" : "ItemPropertyAssociation",
+      "specification" : "ISO",
+      "summary" : "ItemPropertyAssociation",
+      "type" : "ipma"
+    },
+    {
+      "name" : "IPMP Control Box",
+      "specification" : "ISO",
+      "summary" : "IPMP Control Box",
+      "type" : "ipmc"
+    },
+    {
+      "name" : "Item Protection",
+      "specification" : "ISO",
+      "summary" : "item protection",
+      "type" : "ipro"
+    },
+    {
+      "name" : "Item Properties Box",
+      "specification" : "ISO",
+      "summary" : "Item Properties Box",
+      "type" : "iprp"
+    },
+    {
+      "name" : "IPMP Stream",
+      "specification" : "MP4v2",
+      "summary" : "IPMP Stream (category: handler)",
+      "type" : "ipsm"
+    },
+    {
+      "name" : "Item Reference",
+      "specification" : "ISO",
+      "summary" : "Item reference",
+      "type" : "iref"
+    },
+    {
+      "name" : "SVC Region Of Interest Box",
+      "specification" : "NALu Video",
+      "summary" : "SVC region of interest box",
+      "type" : "iroi"
+    },
+    {
+      "name" : "Image Rotation",
+      "specification" : "HEIF",
+      "summary" : "Image rotation",
+      "type" : "irot"
+    },
+    {
+      "name" : "Files Encrypted According To ISMACryp 2.0",
+      "specification" : "ISMACryp2",
+      "summary" : "Files encrypted according to ISMACryp 2.0",
+      "type" : "isc2"
+    },
+    {
+      "name" : "Image Scaling",
+      "specification" : "HEIF",
+      "summary" : "Image scaling",
+      "type" : "iscl"
+    },
+    {
+      "name" : "All Files Based On The 2004 Edition Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "All files based on the 2004 edition of the ISO file format",
+      "type" : "iso2"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso3"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso4"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso5"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso6"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso7"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso8"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "iso9"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "isoa"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "isob"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "isoc"
+    },
+    {
+      "name" : "Version Of The ISO File Format",
+      "specification" : "ISO",
+      "summary" : "Version of the ISO file format",
+      "type" : "isod"
+    },
+    {
+      "name" : "All Files Based On The ISO Base Media File Format",
+      "specification" : "ISO",
+      "summary" : "All files based on the ISO Base Media File Format",
+      "type" : "isom"
+    },
+    {
+      "name" : "Image Spatial Extents",
+      "specification" : "HEIF",
+      "summary" : "Image spatial extents",
+      "type" : "ispe"
+    },
+    {
+      "name" : "T.35 Sample Group",
+      "specification" : "ISO",
+      "summary" : "T.35 sample group (category: sample group)",
+      "type" : "it35"
+    },
+    {
+      "name" : "DVB Track Level Index Track",
+      "specification" : "DVB",
+      "summary" : "DVB Track Level Index Track (handler: Metadata)",
+      "type" : "ixse"
+    },
+    {
+      "name" : "JPEG 2000 Image Sequence In ISO\/IEC 23008-12 Files",
+      "specification" : "J2KHEIF",
+      "summary" : "JPEG 2000 image sequence in ISO\/IEC 23008-12 files",
+      "type" : "j2is"
+    },
+    {
+      "name" : "Contiguous Codestream Box As Specified In Rec. ITU-T T.800 | ISO\/IEC 15444-1",
+      "specification" : "J2KHEIF",
+      "summary" : "Contiguous Codestream box as specified in Rec. ITU-T T.800 | ISO\/IEC 15444-1",
+      "type" : "j2k1"
+    },
+    {
+      "name" : "JPEG 2000 Header Info",
+      "specification" : "J2KHEIF",
+      "summary" : "JPEG 2000 header info",
+      "type" : "j2kH"
+    },
+    {
+      "name" : "JPEG 2000 Prefix",
+      "specification" : "J2KHEIF",
+      "summary" : "JPEG 2000 prefix",
+      "type" : "j2kP"
+    },
+    {
+      "name" : "Sequence Of JPEG 2000 Contiguous Codestream Boxes As Defined In Rec. ITU-T T.800 | ISO\/IEC 15444-1",
+      "specification" : "J2KHEIF",
+      "summary" : "Sequence of JPEG 2000 Contiguous Codestream boxes as defined in Rec. ITU-T T.800 | ISO\/IEC 15444-1 (handler: Video)",
+      "type" : "j2ki"
+    },
+    {
+      "name" : "Motion JPEG 2000 In ISO\/IEC 23008-12 Files",
+      "specification" : "J2KHEIF",
+      "summary" : "Motion JPEG 2000 in ISO\/IEC 23008-12 files",
+      "type" : "j2ks"
+    },
+    {
+      "name" : "JPEG 2000 Signature",
+      "specification" : "JPEG2000",
+      "summary" : "JPEG 2000 Signature",
+      "type" : "jP  "
+    },
+    {
+      "name" : "JPEG Bitstream Reconstruction Data",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG bitstream reconstruction data",
+      "type" : "jbrd"
+    },
+    {
+      "name" : "JPEG2000 Part 1",
+      "specification" : "JPEG2000",
+      "summary" : "JPEG2000 Part 1",
+      "type" : "jp2 "
+    },
+    {
+      "name" : "JPEG 2000 Contiguous Codestream",
+      "specification" : "JPEG2000",
+      "summary" : "JPEG 2000 contiguous codestream",
+      "type" : "jp2c"
+    },
+    {
+      "name" : "Header",
+      "specification" : "JPEG2000",
+      "summary" : "Header",
+      "type" : "jp2h"
+    },
+    {
+      "name" : "Intellectual Property Information",
+      "specification" : "JPEG2000",
+      "summary" : "intellectual property information",
+      "type" : "jp2i"
+    },
+    {
+      "name" : "JPEG Image Item",
+      "specification" : "HEIF",
+      "summary" : "JPEG image item",
+      "type" : "jpeg"
+    },
+    {
+      "name" : "JPEG Configuration",
+      "specification" : "HEIF",
+      "summary" : "JPEG Configuration (handler: Image Item and Image sequences)",
+      "type" : "jpgC"
+    },
+    {
+      "name" : "JPEG Image Sequence Brands",
+      "specification" : "HEIF",
+      "summary" : "JPEG image sequence brands",
+      "type" : "jpgs"
+    },
+    {
+      "name" : "JPEG 2000 Part 6 Compound Images",
+      "specification" : "JPM",
+      "summary" : "JPEG 2000 Part 6 Compound Images",
+      "type" : "jpm "
+    },
+    {
+      "name" : "OMAF Legacy Image Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF legacy image profile",
+      "type" : "jpoi"
+    },
+    {
+      "name" : "The JPSearch Data Interchange Format, For The Exchange Of Image Collections And Respective Metadata",
+      "specification" : "JPSearch",
+      "summary" : "The JPSearch data interchange format, for the exchange of image collections and respective metadata",
+      "type" : "jpsi"
+    },
+    {
+      "name" : "JPEG XS Video Transport Parameter",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Video Transport Parameter",
+      "type" : "jptp"
+    },
+    {
+      "name" : "JPEG XS Video Information",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Video Information",
+      "type" : "jpvi"
+    },
+    {
+      "name" : "JPEG XS Video Support",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Video Support",
+      "type" : "jpvs"
+    },
+    {
+      "name" : "JPEG2000 Part 2",
+      "specification" : "JPX",
+      "summary" : "JPEG2000 Part 2",
+      "type" : "jpx "
+    },
+    {
+      "name" : "JPEG XR",
+      "specification" : "JPXR",
+      "summary" : "JPEG XR",
+      "type" : "jpxb"
+    },
+    {
+      "name" : "JPEG Universal Metadata Box Format (JUMBF)",
+      "specification" : "JPEG Systems",
+      "summary" : "JPEG Universal Metadata Box Format (JUMBF)",
+      "type" : "jumb"
+    },
+    {
+      "name" : "JPEG XL",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL",
+      "type" : "jxl "
+    },
+    {
+      "name" : "JPEG XL Codestream",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL Codestream",
+      "type" : "jxlc"
+    },
+    {
+      "name" : "JPEG XL Frame Index",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL Frame Index",
+      "type" : "jxli"
+    },
+    {
+      "name" : "JPEG XL Level",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL Level",
+      "type" : "jxll"
+    },
+    {
+      "name" : "JPEG XL Partial Codestream",
+      "specification" : "JPEG XL",
+      "summary" : "JPEG XL Partial Codestream",
+      "type" : "jxlp"
+    },
+    {
+      "name" : "JPEG XS Profile And Level",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Profile and Level",
+      "type" : "jxpl"
+    },
+    {
+      "name" : "Still Image File Format For JPEG XS",
+      "specification" : "JPXS",
+      "summary" : "Still Image File Format for JPEG XS",
+      "type" : "jxs "
+    },
+    {
+      "name" : "Images Coded To The JPEG-XS Coding Format",
+      "specification" : "JPXS",
+      "summary" : "Images coded to the JPEG-XS coding format",
+      "type" : "jxs1"
+    },
+    {
+      "name" : "JPEG XS Header",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS Header",
+      "type" : "jxsH"
+    },
+    {
+      "name" : "Codestream For JPEG XS",
+      "specification" : "JPXS",
+      "summary" : "Codestream for JPEG XS",
+      "type" : "jxsc"
+    },
+    {
+      "name" : "JPEG XS Image And Image Collections For HEIF",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS image and image collections for HEIF",
+      "type" : "jxsi"
+    },
+    {
+      "name" : "Video And Image Sequences Coded To The JPEG-XS Coding Format",
+      "specification" : "JPXS",
+      "summary" : "Video and image sequences coded to the JPEG-XS coding format (handler: Video)",
+      "type" : "jxsm"
+    },
+    {
+      "name" : "JPEG XS Image Sequences For HEIF",
+      "specification" : "JPXS",
+      "summary" : "JPEG XS image sequences for HEIF",
+      "type" : "jxss"
+    },
+    {
+      "name" : "Track Kind",
+      "specification" : "ISO",
+      "summary" : "Track kind",
+      "type" : "kind"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "kmat"
+    },
+    {
+      "name" : "Media Keywords",
+      "specification" : "3GPP",
+      "summary" : "Media keywords",
+      "type" : "kywd"
+    },
+    {
+      "name" : "Label Box",
+      "specification" : "ISO",
+      "summary" : "Label box",
+      "type" : "labl"
+    },
+    {
+      "name" : "Track Differs In Language",
+      "specification" : "3GPP",
+      "summary" : "Track differs in language (category: track sel.)",
+      "type" : "lang"
+    },
+    {
+      "name" : "HEVC External Base Layer",
+      "specification" : "NALu Video",
+      "summary" : "HEVC External base layer (category: sample group)",
+      "type" : "lbli"
+    },
+    {
+      "name" : "Tier Dependency Box",
+      "specification" : "NALu Video",
+      "summary" : "Tier dependency box",
+      "type" : "ldep"
+    },
+    {
+      "name" : "Loudness Equalization Instructions",
+      "specification" : "DRC",
+      "summary" : "Loudness equalization instructions (handler: Audio)",
+      "type" : "leqi"
+    },
+    {
+      "name" : "Leval Assignment",
+      "specification" : "ISO",
+      "summary" : "Leval assignment",
+      "type" : "leva"
+    },
+    {
+      "name" : "Level",
+      "specification" : "NALu Video",
+      "summary" : "Level (category: Multiview Reln. Attribute)",
+      "type" : "levl"
+    },
+    {
+      "name" : "Layered HEVC",
+      "specification" : "NALu Video",
+      "summary" : "Layered HEVC (handler: Video)",
+      "type" : "lhe1"
+    },
+    {
+      "name" : "Layered HEVC Tile Tracks",
+      "specification" : "NALu Video",
+      "summary" : "Layered HEVC tile tracks (handler: Video)",
+      "type" : "lht1"
+    },
+    {
+      "name" : "L-HEVC Tile Track Explicit Brand",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC Tile Track Explicit brand",
+      "type" : "lhte"
+    },
+    {
+      "name" : "L-HEVC Tile Track Implicit Brand",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC Tile Track Implicit brand",
+      "type" : "lhti"
+    },
+    {
+      "name" : "Layered HEVC",
+      "specification" : "NALu Video",
+      "summary" : "Layered HEVC (handler: Video)",
+      "type" : "lhv1"
+    },
+    {
+      "name" : "Layered HEVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "Layered HEVC Configuration (handler: Video)",
+      "type" : "lhvC"
+    },
+    {
+      "name" : "L-HEVC And VVC Layer Information",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC and VVC layer information (category: sample group)",
+      "type" : "linf"
+    },
+    {
+      "name" : "Last Media Segment Indicator For ISO Base Media File Format.",
+      "specification" : "DASH",
+      "summary" : "last Media Segment indicator for ISO base media file format.",
+      "type" : "lmsg"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "load"
+    },
+    {
+      "name" : "Media Location Information",
+      "specification" : "3GPP",
+      "summary" : "Media location information",
+      "type" : "loci"
+    },
+    {
+      "name" : "Looping Behavior",
+      "specification" : "WhatsApp",
+      "summary" : "Looping behavior",
+      "type" : "loop"
+    },
+    {
+      "name" : "OMA DRM Lyrics URI",
+      "specification" : "OMA DRM 2.1",
+      "summary" : "OMA DRM Lyrics URI",
+      "type" : "lrcu"
+    },
+    {
+      "name" : "Layer Selection",
+      "specification" : "HEIF",
+      "summary" : "Layer selection",
+      "type" : "lsel"
+    },
+    {
+      "name" : "Track Loudness Container",
+      "specification" : "ISO",
+      "summary" : "Track loudness container",
+      "type" : "ludt"
+    },
+    {
+      "name" : "LCEVC Video Track",
+      "specification" : "NALu Video",
+      "summary" : "LCEVC video track (handler: Video)",
+      "type" : "lvc1"
+    },
+    {
+      "name" : "LCEVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "LCEVC configuration (handler: Video)",
+      "type" : "lvcC"
+    },
+    {
+      "name" : "Audio Layer Track Dependency",
+      "specification" : "DTS",
+      "summary" : "Audio layer track dependency",
+      "type" : "lyra"
+    },
+    {
+      "name" : "MPEG-2 Transport Stream For DMB",
+      "specification" : "DMB-MAF",
+      "summary" : "MPEG-2 transport stream for DMB (handler: Hint)",
+      "type" : "m2ts"
+    },
+    {
+      "name" : "MPEG-4 Audio Enhancement",
+      "specification" : "MP4v2",
+      "summary" : "MPEG-4 Audio Enhancement (handler: Audio, objectType: 0x40, others)",
+      "type" : "m4ae"
+    },
+    {
+      "name" : "MPEG-4 Descriptors",
+      "specification" : "NALu Video",
+      "summary" : "MPEG-4 descriptors (handler: General)",
+      "type" : "m4ds"
+    },
+    {
+      "name" : "Reserved For MPEG7Stream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for MPEG7Stream header",
+      "type" : "m7hd"
+    },
+    {
+      "name" : "MPEG7Stream",
+      "specification" : "MP4v2",
+      "summary" : "MPEG7Stream (category: handler)",
+      "type" : "m7sm"
+    },
+    {
+      "name" : "MPEG-H Audio Scene Information",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio scene information (handler: Audio)",
+      "type" : "maeI"
+    },
+    {
+      "name" : "MPEG-H Audio Multi-stream Signalling",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio multi-stream signalling (handler: Audio)",
+      "type" : "maeM"
+    },
+    {
+      "name" : "Manufacturer Name Of The Camera",
+      "specification" : "Apple",
+      "summary" : "Manufacturer name of the camera",
+      "type" : "manu"
+    },
+    {
+      "name" : "Region Mask Reference",
+      "specification" : "HEIF",
+      "summary" : "Region mask reference (category: item ref.)",
+      "type" : "mask"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "matt"
+    },
+    {
+      "name" : "Model Coordinate Reference System",
+      "specification" : "OGC 24-038",
+      "summary" : "Model coordinate reference system",
+      "type" : "mcrs"
+    },
+    {
+      "name" : "MD5 Checksum As Specified In RFC 6151",
+      "specification" : "ISO-Partial",
+      "summary" : "MD5 checksum as specified in RFC 6151",
+      "type" : "md5 "
+    },
+    {
+      "name" : "MD5IntegrityBox",
+      "specification" : "HEIF",
+      "summary" : "MD5IntegrityBox",
+      "type" : "md5i"
+    },
+    {
+      "name" : "Media Data Container",
+      "specification" : "ISO\/IEC 14496-12",
+      "summary" : "Holds the raw media samples referenced by the track sample tables.",
+      "type" : "mdat"
+    },
+    {
+      "name" : "Mastering Display Colour Volume",
+      "specification" : "ISO",
+      "summary" : "mastering display colour volume (handler: Video)",
+      "type" : "mdcv"
+    },
+    {
+      "name" : "Modification Time Information",
+      "specification" : "HEIF",
+      "summary" : "Modification time information",
+      "type" : "mdft"
+    },
+    {
+      "name" : "Media Header, Overall Information About The Media",
+      "specification" : "ISO",
+      "summary" : "media header, overall information about the media",
+      "type" : "mdhd"
+    },
+    {
+      "name" : "Container For The Media Information In A Track",
+      "specification" : "ISO",
+      "summary" : "container for the media information in a track",
+      "type" : "mdia"
+    },
+    {
+      "name" : "Mutable DRM Information",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "Mutable DRM information",
+      "type" : "mdri"
+    },
+    {
+      "name" : "Timed Metadata Multiplex",
+      "specification" : "ISO",
+      "summary" : "Timed metadata multiplex (handler: Metadata)",
+      "type" : "mebx"
+    },
+    {
+      "name" : "Additional Metadata Container",
+      "specification" : "ISO",
+      "summary" : "additional metadata container",
+      "type" : "meco"
+    },
+    {
+      "name" : "Movie Extends Header Box",
+      "specification" : "ISO",
+      "summary" : "movie extends header box",
+      "type" : "mehd"
+    },
+    {
+      "name" : "Track Differs In Language",
+      "specification" : "ISO",
+      "summary" : "Track differs in language (category: track sel.)",
+      "type" : "mela"
+    },
+    {
+      "name" : "Media Offset",
+      "specification" : "OMAF",
+      "summary" : "media offset",
+      "type" : "meof"
+    },
+    {
+      "name" : "Closed Scheme Type For Mesh Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "Closed scheme type for mesh omnidirectional video (category: restricted video scheme)",
+      "type" : "meov"
+    },
+    {
+      "name" : "Metabox Relation",
+      "specification" : "ISO",
+      "summary" : "metabox relation",
+      "type" : "mere"
+    },
+    {
+      "name" : "Mesh Box",
+      "specification" : "OMAF",
+      "summary" : "mesh box",
+      "type" : "mesh"
+    },
+    {
+      "name" : "Metadata",
+      "specification" : "ISO",
+      "summary" : "Metadata (category: handler)",
+      "type" : "meta"
+    },
+    {
+      "name" : "Text Timed Metadata That Is Not XML",
+      "specification" : "ISO",
+      "summary" : "Text timed metadata that is not XML (handler: Metadata)",
+      "type" : "mett"
+    },
+    {
+      "name" : "XML Timed Metadata",
+      "specification" : "ISO",
+      "summary" : "XML timed metadata (handler: Metadata)",
+      "type" : "metx"
+    },
+    {
+      "name" : "Movie Fragment Header",
+      "specification" : "ISO",
+      "summary" : "movie fragment header",
+      "type" : "mfhd"
+    },
+    {
+      "name" : "Movie Fragment Random Access",
+      "specification" : "ISO",
+      "summary" : "Movie fragment random access",
+      "type" : "mfra"
+    },
+    {
+      "name" : "Movie Fragment Random Access Offset",
+      "specification" : "ISO",
+      "summary" : "Movie fragment random access offset",
+      "type" : "mfro"
+    },
+    {
+      "name" : "MPEG-H Audio (single Stream, Unencapsulated)",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio (single stream, unencapsulated) (handler: Audio)",
+      "type" : "mha1"
+    },
+    {
+      "name" : "MPEG-H Audio (multi-stream, Unencapsulated)",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio (multi-stream, unencapsulated) (handler: Audio)",
+      "type" : "mha2"
+    },
+    {
+      "name" : "MPEG-H Audio Decoder Configuration",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio Decoder Configuration (handler: Audio)",
+      "type" : "mhaC"
+    },
+    {
+      "name" : "MPEG-H Audio Dynamic Range Control And Loudness",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio dynamic range control and loudness (handler: Audio)",
+      "type" : "mhaD"
+    },
+    {
+      "name" : "MPEG-H Audio Profile And Level Compatibility Set",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio profile and level compatibility set (handler: Audio)",
+      "type" : "mhaP"
+    },
+    {
+      "name" : "MPEG-H Audio (single Stream, MHAS Encapsulated)",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio (single stream, MHAS encapsulated) (handler: Audio)",
+      "type" : "mhm1"
+    },
+    {
+      "name" : "MPEG-H Audio (multi-stream, MHAS Encapsulated)",
+      "specification" : "MPEG-H",
+      "summary" : "MPEG-H Audio (multi-stream, MHAS encapsulated) (handler: Audio)",
+      "type" : "mhm2"
+    },
+    {
+      "name" : "Multi-Image Application Format Brand For General MIAF Requirements",
+      "specification" : "MIAF",
+      "summary" : "Multi-Image Application format brand for general MIAF requirements",
+      "type" : "miaf"
+    },
+    {
+      "name" : "Image File Format Structural Brand",
+      "specification" : "HEIF",
+      "summary" : "Image file format structural brand",
+      "type" : "mif1"
+    },
+    {
+      "name" : "Image File Format Structural Brand CICP Alpha And Depth",
+      "specification" : "HEIF",
+      "summary" : "Image file format structural brand CICP alpha and depth",
+      "type" : "mif2"
+    },
+    {
+      "name" : "Item Identified By A MIME Type",
+      "specification" : "ISO",
+      "summary" : "Item identified by a MIME type",
+      "type" : "mime"
+    },
+    {
+      "name" : "Media Information Container",
+      "specification" : "ISO",
+      "summary" : "media information container",
+      "type" : "minf"
+    },
+    {
+      "name" : "VVC Mixed NAL Unit Type Pictures",
+      "specification" : "NALu Video",
+      "summary" : "VVC mixed NAL unit type pictures (category: sample group)",
+      "type" : "minp"
+    },
+    {
+      "name" : "Data Integrity Reference",
+      "specification" : "HEIF",
+      "summary" : "Data integrity reference (category: item ref.)",
+      "type" : "mint"
+    },
+    {
+      "name" : "Used In Indicating Combinations That Result Into Mixed Network Abstraction Layer Unit Types In A Coded Picture Of VVC",
+      "specification" : "NALu Video",
+      "summary" : "used in indicating combinations that result into mixed network abstraction layer unit types in a coded picture of VVC",
+      "type" : "mixn"
+    },
+    {
+      "name" : "Motion JPEG 2000 Simple Profile",
+      "specification" : "MJ2",
+      "summary" : "Motion JPEG 2000 simple profile",
+      "type" : "mj2s"
+    },
+    {
+      "name" : "Reserved For MPEG-J Stream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for MPEG-J Stream header",
+      "type" : "mjhd"
+    },
+    {
+      "name" : "Motion JPEG 2000",
+      "specification" : "MJ2",
+      "summary" : "Motion JPEG 2000 (handler: Video)",
+      "type" : "mjp2"
+    },
+    {
+      "name" : "JPEG Image Sequences",
+      "specification" : "HEIF",
+      "summary" : "JPEG image sequences (handler: Video)",
+      "type" : "mjpg"
+    },
+    {
+      "name" : "MPEG-J Stream",
+      "specification" : "MP4v2",
+      "summary" : "MPEG-J Stream (category: handler)",
+      "type" : "mjsm"
+    },
+    {
+      "name" : "DVB Movie Level Index Track",
+      "specification" : "DVB",
+      "summary" : "DVB Movie level index track (handler: Metadata)",
+      "type" : "mlix"
+    },
+    {
+      "name" : "MLP Audio",
+      "specification" : "Dolby MLP",
+      "summary" : "MLP Audio (handler: Audio)",
+      "type" : "mlpa"
+    },
+    {
+      "name" : "Multimap Video",
+      "specification" : "V3C-SYS",
+      "summary" : "multimap video",
+      "type" : "mmvi"
+    },
+    {
+      "name" : "Model Name Of The Camera",
+      "specification" : "Apple",
+      "summary" : "Model name of the camera",
+      "type" : "modl"
+    },
+    {
+      "name" : "Open-ended Scheme Type For Mesh Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "Open-ended scheme type for mesh omnidirectional video (category: restricted video scheme)",
+      "type" : "modv"
+    },
+    {
+      "name" : "Movie Fragment",
+      "specification" : "ISO",
+      "summary" : "movie fragment",
+      "type" : "moof"
+    },
+    {
+      "name" : "Container For All The Meta-data",
+      "specification" : "ISO\/IEC 14496-12",
+      "summary" : "Top-level container for movie metadata including tracks and timing information.",
+      "type" : "moov"
+    },
+    {
+      "name" : "Mesh Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "mesh omnidirectional video",
+      "type" : "movd"
+    },
+    {
+      "name" : "MPEG-21 Digital Item",
+      "specification" : "MPEG-21",
+      "summary" : "MPEG-21 Digital item (category: handler)",
+      "type" : "mp21"
+    },
+    {
+      "name" : "MP4 Version 1",
+      "specification" : "MP4v2",
+      "summary" : "MP4 version 1",
+      "type" : "mp41"
+    },
+    {
+      "name" : "MP4 Version 2",
+      "specification" : "MP4v2",
+      "summary" : "MP4 version 2",
+      "type" : "mp42"
+    },
+    {
+      "name" : "MPEG-4 Audio",
+      "specification" : "MP4v2",
+      "summary" : "MPEG-4 Audio (handler: Audio, objectType: 0x40, others)",
+      "type" : "mp4a"
+    },
+    {
+      "name" : "MPEG-4 Systems",
+      "specification" : "MP4v2",
+      "summary" : "MPEG-4 Systems (handler: (various), objectType: various)",
+      "type" : "mp4s"
+    },
+    {
+      "name" : "MPEG-4 Visual",
+      "specification" : "MP4v2",
+      "summary" : "MPEG-4 Visual (handler: Video, objectType: 0x20, others)",
+      "type" : "mp4v"
+    },
+    {
+      "name" : "MPEG-7 File-level Metadata",
+      "specification" : "ISO",
+      "summary" : "MPEG-7 file-level metadata",
+      "type" : "mp71"
+    },
+    {
+      "name" : "MPEG-7 (binary Meta-data)",
+      "specification" : "ISO",
+      "summary" : "MPEG-7 (binary meta-data) (category: handler)",
+      "type" : "mp7b"
+    },
+    {
+      "name" : "MPEG-7 (textual Meta-data)",
+      "specification" : "ISO",
+      "summary" : "MPEG-7 (textual meta-data) (category: handler)",
+      "type" : "mp7t"
+    },
+    {
+      "name" : "MPD Contained In A Metabox",
+      "specification" : "3GPP",
+      "summary" : "MPD contained in a metabox (category: handler)",
+      "type" : "mpd "
+    },
+    {
+      "name" : "MPD Link Contained In A Metabox",
+      "specification" : "3GPP",
+      "summary" : "MPD link contained in a metabox (category: handler)",
+      "type" : "mpdl"
+    },
+    {
+      "name" : "This Track Is An OD Track Which Uses The Referenced Track As An Included Elementary Stream Track",
+      "specification" : "MP4v2",
+      "summary" : "this track is an OD track which uses the referenced track as an included elementary stream track",
+      "type" : "mpod"
+    },
+    {
+      "name" : "Track Differs In The Maximum RTP Packet Size",
+      "specification" : "ISO",
+      "summary" : "Track differs in the maximum RTP Packet size (category: track sel.)",
+      "type" : "mpsz"
+    },
+    {
+      "name" : "Compliance With The MMT Processing Unit Format",
+      "specification" : "MMT",
+      "summary" : "Compliance with the MMT Processing Unit format",
+      "type" : "mpuf"
+    },
+    {
+      "name" : "Media Segment Conforming To The General Format Type For ISO Base Media File Format.",
+      "specification" : "DASH",
+      "summary" : "Media Segment conforming to the general format type for ISO base media file format.",
+      "type" : "msdh"
+    },
+    {
+      "name" : "Image File Format Structural Brand",
+      "specification" : "HEIF",
+      "summary" : "Image file format structural brand",
+      "type" : "msf1"
+    },
+    {
+      "name" : "Media Segment Conforming To The Indexed Media Segment Format Type For ISO Base Media File Format.",
+      "specification" : "DASH",
+      "summary" : "Media Segment conforming to the Indexed Media Segment format type for ISO base media file format.",
+      "type" : "msix"
+    },
+    {
+      "name" : "Mask Item Configuration",
+      "specification" : "HEIF",
+      "summary" : "Mask item configuration",
+      "type" : "mskC"
+    },
+    {
+      "name" : "Mask Item",
+      "specification" : "HEIF",
+      "summary" : "Mask item",
+      "type" : "mski"
+    },
+    {
+      "name" : "Multi-source Presentation Track Grouping",
+      "specification" : "ISO",
+      "summary" : "multi-source presentation track grouping",
+      "type" : "msrc"
+    },
+    {
+      "name" : "MVC Sub Track View Box",
+      "specification" : "NALu Video",
+      "summary" : "MVC sub track view box",
+      "type" : "mstv"
+    },
+    {
+      "name" : "Model Transformation",
+      "specification" : "OGC 24-038",
+      "summary" : "Model transformation",
+      "type" : "mtxf"
+    },
+    {
+      "name" : "Track Differs In Media Type (handler Type)",
+      "specification" : "ISO",
+      "summary" : "Track differs in media type (handler type) (category: track sel.)",
+      "type" : "mtyp"
+    },
+    {
+      "name" : "QuickTime Music Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime Music track handler (category: handler)",
+      "type" : "musi"
+    },
+    {
+      "name" : "Apple HEVC Video With Alpha",
+      "specification" : "Apple HEVC Alpha",
+      "summary" : "Apple HEVC Video with Alpha",
+      "type" : "muxa"
+    },
+    {
+      "name" : "Multiview Coding",
+      "specification" : "NALu Video",
+      "summary" : "Multiview coding (handler: Video)",
+      "type" : "mvc1"
+    },
+    {
+      "name" : "Multiview Coding",
+      "specification" : "NALu Video",
+      "summary" : "Multiview coding (handler: Video)",
+      "type" : "mvc2"
+    },
+    {
+      "name" : "Multiview Coding",
+      "specification" : "NALu Video",
+      "summary" : "Multiview coding (handler: Video)",
+      "type" : "mvc3"
+    },
+    {
+      "name" : "Multiview Coding",
+      "specification" : "NALu Video",
+      "summary" : "Multiview coding (handler: Video)",
+      "type" : "mvc4"
+    },
+    {
+      "name" : "MVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "MVC configuration (handler: Video)",
+      "type" : "mvcC"
+    },
+    {
+      "name" : "MVC Priority Assignment",
+      "specification" : "NALu Video",
+      "summary" : "MVC priority assignment (handler: Video)",
+      "type" : "mvcP"
+    },
+    {
+      "name" : "Multiview Group",
+      "specification" : "NALu Video",
+      "summary" : "Multiview group",
+      "type" : "mvcg"
+    },
+    {
+      "name" : "Multiview Information",
+      "specification" : "NALu Video",
+      "summary" : "Multiview Information",
+      "type" : "mvci"
+    },
+    {
+      "name" : "MVD Stream",
+      "specification" : "NALu Video",
+      "summary" : "MVD stream (handler: Video)",
+      "type" : "mvd1"
+    },
+    {
+      "name" : "MVD Stream",
+      "specification" : "NALu Video",
+      "summary" : "MVD stream (handler: Video)",
+      "type" : "mvd2"
+    },
+    {
+      "name" : "MVD Stream",
+      "specification" : "NALu Video",
+      "summary" : "MVD stream (handler: Video)",
+      "type" : "mvd3"
+    },
+    {
+      "name" : "MVD Stream",
+      "specification" : "NALu Video",
+      "summary" : "MVD stream (handler: Video)",
+      "type" : "mvd4"
+    },
+    {
+      "name" : "MVCDConfigurationBox",
+      "specification" : "NALu Video",
+      "summary" : "MVCDConfigurationBox (handler: Video)",
+      "type" : "mvdC"
+    },
+    {
+      "name" : "Movie Extends Box",
+      "specification" : "ISO",
+      "summary" : "movie extends box",
+      "type" : "mvex"
+    },
+    {
+      "name" : "Movie Header, Overall Declarations",
+      "specification" : "ISO",
+      "summary" : "movie header, overall declarations",
+      "type" : "mvhd"
+    },
+    {
+      "name" : "MVC Scalability Information",
+      "specification" : "NALu Video",
+      "summary" : "MVC Scalability Information (category: sample group)",
+      "type" : "mvif"
+    },
+    {
+      "name" : "Multiview Relation Attribute",
+      "specification" : "NALu Video",
+      "summary" : "Multiview Relation Attribute",
+      "type" : "mvra"
+    },
+    {
+      "name" : "NAL Unit Map Entry",
+      "specification" : "NALu Video",
+      "summary" : "NAL unit map entry (category: sample group)",
+      "type" : "nalm"
+    },
+    {
+      "name" : "Normal Color Information",
+      "specification" : "ISO",
+      "summary" : "Normal color information (category: Color info)",
+      "type" : "nclx"
+    },
+    {
+      "name" : "Indicates The Samples Where The Neural-network Post-filter (NNPF) With Is Active According To NNPF Activation SEI Messages Present In The Track",
+      "specification" : "NALu Video",
+      "summary" : "Indicates the samples where the neural-network post-filter (NNPF) with is active according to NNPF activation SEI messages present in the track (category: sample group)",
+      "type" : "nfas"
+    },
+    {
+      "name" : "Efficient Representation Of Neural-network Post-filter Characteristics SEI Messages",
+      "specification" : "NALu Video",
+      "summary" : "Efficient representation of neural-network post-filter characteristics SEI messages (category: sample group)",
+      "type" : "nfcs"
+    },
+    {
+      "name" : "Nikon Digital Camera",
+      "specification" : "Nikon",
+      "summary" : "Nikon Digital Camera",
+      "type" : "niko"
+    },
+    {
+      "name" : "Non-linear Storyline Toolset Brand",
+      "specification" : "OMAF",
+      "summary" : "Non-linear storyline toolset brand",
+      "type" : "nlsl"
+    },
+    {
+      "name" : "Null Media Header, Overall Information (some Tracks Only)",
+      "specification" : "ISO",
+      "summary" : "Null media header, overall information (some tracks only)",
+      "type" : "nmhd"
+    },
+    {
+      "name" : "Neural Network Handler (items Defined In The MetaBox Represent Neural Networks)",
+      "specification" : "NALu Video",
+      "summary" : "Neural network handler (items defined in the MetaBox represent neural networks) (category: handler)",
+      "type" : "nnet"
+    },
+    {
+      "name" : "NNR Item That Carries A Bitstream Conforming To ISO\/IEC 15398-17 (Neural Network Representation NNR, Also Known As Neural Network Coding, NNC)",
+      "specification" : "NALu Video",
+      "summary" : "NNR Item that carries a bitstream conforming to ISO\/IEC 15398-17 (Neural Network Representation NNR, also known as Neural Network Coding, NNC)",
+      "type" : "nnr1"
+    },
+    {
+      "name" : "Configuration Item Property For 'nnr1' Item",
+      "specification" : "NALu Video",
+      "summary" : "Configuration item property for 'nnr1' item",
+      "type" : "nnrC"
+    },
+    {
+      "name" : "No Leading Picture Sync Brand",
+      "specification" : "NALu Video",
+      "summary" : "No Leading Picture Sync Brand",
+      "type" : "nras"
+    },
+    {
+      "name" : "Non-Real Time Metadata (XAVC Format)",
+      "specification" : "Sony",
+      "summary" : "Non-Real Time Metadata (XAVC Format) (category: handler)",
+      "type" : "nrtm"
+    },
+    {
+      "name" : "No Handling Required (meta-data)",
+      "specification" : "ISO",
+      "summary" : "No handling required (meta-data) (category: handler)",
+      "type" : "null"
+    },
+    {
+      "name" : "YUV 420 8 Bits Semi-planar Y CbCr",
+      "specification" : "UNCV",
+      "summary" : "YUV 420 8 bits semi-planar Y CbCr",
+      "type" : "nv12"
+    },
+    {
+      "name" : "YUV 420 8 Bits Semi-planar Y CrCb",
+      "specification" : "UNCV",
+      "summary" : "YUV 420 8 bits semi-planar Y CrCb",
+      "type" : "nv21"
+    },
+    {
+      "name" : "Number Of Views In The Sub Track",
+      "specification" : "ISO",
+      "summary" : "Number of views in the sub track (category: track sel.)",
+      "type" : "nvws"
+    },
+    {
+      "name" : "OMAF 2D Audio Legacy Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF 2D audio legacy profile",
+      "type" : "oa2d"
+    },
+    {
+      "name" : "OMAF 3D Audio Baseline Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF 3D audio baseline profile",
+      "type" : "oabl"
+    },
+    {
+      "name" : "Reserved For ObjectContentInfoStream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for ObjectContentInfoStream header",
+      "type" : "ochd"
+    },
+    {
+      "name" : "Object Centre Points Correspondence Between Viewpoints",
+      "specification" : "OMAF",
+      "summary" : "Object centre points correspondence between viewpoints (handler: Metadata)",
+      "type" : "ocpc"
+    },
+    {
+      "name" : "ObjectContentInfoStream",
+      "specification" : "MP4v2",
+      "summary" : "ObjectContentInfoStream (category: handler)",
+      "type" : "ocsm"
+    },
+    {
+      "name" : "OMA DRM Access Unit Format",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Access Unit Format",
+      "type" : "odaf"
+    },
+    {
+      "name" : "OMA DCF (DRM Content Format)",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DCF (DRM Content Format)",
+      "type" : "odcf"
+    },
+    {
+      "name" : "OMA DRM Content Object",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Content Object",
+      "type" : "odda"
+    },
+    {
+      "name" : "Reserved For ObjectDescriptorStream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for ObjectDescriptorStream header",
+      "type" : "odhd"
+    },
+    {
+      "name" : "OMA DRM Discrete Media Headers",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Discrete Media Headers",
+      "type" : "odhe"
+    },
+    {
+      "name" : "OMA DRM KMS Protection Scheme",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM KMS protection scheme (category: protection scheme)",
+      "type" : "odkm"
+    },
+    {
+      "name" : "OMA DRM Rights Object",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Rights Object",
+      "type" : "odrb"
+    },
+    {
+      "name" : "OMA DRM Container",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Container",
+      "type" : "odrm"
+    },
+    {
+      "name" : "ObjectDescriptorStream",
+      "specification" : "MP4v2",
+      "summary" : "ObjectDescriptorStream (category: handler)",
+      "type" : "odsm"
+    },
+    {
+      "name" : "OMA DRM Transaction Tracking",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Transaction Tracking",
+      "type" : "odtt"
+    },
+    {
+      "name" : "OMA DRM Common Headers",
+      "specification" : "OMA DRM 2.0",
+      "summary" : "OMA DRM Common headers",
+      "type" : "ohdr"
+    },
+    {
+      "name" : "L-HEVC Operating Points Information",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC operating points information (category: sample group)",
+      "type" : "oinf"
+    },
+    {
+      "name" : "OMA Keys",
+      "specification" : "OMA DRM XBS",
+      "summary" : "OMA Keys (handler: Metadata)",
+      "type" : "oksd"
+    },
+    {
+      "name" : "OMAF Viewport-independent Baseline Presentation Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF viewport-independent baseline presentation profile",
+      "type" : "ompp"
+    },
+    {
+      "name" : "VVC Operating Points",
+      "specification" : "NALu Video",
+      "summary" : "VVC operating points",
+      "type" : "opeg"
+    },
+    {
+      "name" : "OMA PDCF (DRM Content Format)",
+      "specification" : "OMA DRM 2.1",
+      "summary" : "OMA PDCF (DRM Content Format)",
+      "type" : "opf2"
+    },
+    {
+      "name" : "L-HEVC And VVC Operating Point Decode Time Hint",
+      "specification" : "NALu Video",
+      "summary" : "L-HEVC and VVC Operating Point Decode Time Hint (category: sample group)",
+      "type" : "opth"
+    },
+    {
+      "name" : "OMA Adapted PDCF",
+      "specification" : "OMA DRM XBS",
+      "summary" : "OMA Adapted PDCF",
+      "type" : "opx2"
+    },
+    {
+      "name" : "Track That Contains An 'oref' Sample Group",
+      "specification" : "NALu Video",
+      "summary" : "track that contains an 'oref' sample group",
+      "type" : "oref"
+    },
+    {
+      "name" : "Orientation Information",
+      "specification" : "3GPP",
+      "summary" : "Orientation information",
+      "type" : "orie"
+    },
+    {
+      "name" : "OMAF Timed Text Configuration",
+      "specification" : "OMAF",
+      "summary" : "OMAF timed text configuration",
+      "type" : "otcf"
+    },
+    {
+      "name" : "Original File Type",
+      "specification" : "ISO",
+      "summary" : "Original file type",
+      "type" : "otyp"
+    },
+    {
+      "name" : "Grouping Of Overlays That Are Alternatives For Switching",
+      "specification" : "OMAF",
+      "summary" : "Grouping of overlays that are alternatives for switching",
+      "type" : "oval"
+    },
+    {
+      "name" : "Grouping Of Overlays And Background Visual Media That Are Intended To Be Presented Together",
+      "specification" : "OMAF",
+      "summary" : "Grouping of overlays and background visual media that are intended to be presented together",
+      "type" : "ovbg"
+    },
+    {
+      "name" : "OMAF Viewport-dependent Baseline Presentation Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF viewport-dependent baseline presentation profile",
+      "type" : "ovdp"
+    },
+    {
+      "name" : "Overlay Configuration",
+      "specification" : "OMAF",
+      "summary" : "Overlay configuration",
+      "type" : "ovly"
+    },
+    {
+      "name" : "Sample Padding Bits",
+      "specification" : "ISO",
+      "summary" : "sample padding bits",
+      "type" : "padb"
+    },
+    {
+      "name" : "Partition Entry",
+      "specification" : "ISO",
+      "summary" : "Partition Entry",
+      "type" : "paen"
+    },
+    {
+      "name" : "Generic Partial File",
+      "specification" : "ISO-Partial",
+      "summary" : "Generic Partial File",
+      "type" : "paff"
+    },
+    {
+      "name" : "Panasonic Digital Camera",
+      "specification" : "Panasonic",
+      "summary" : "Panasonic Digital Camera",
+      "type" : "pana"
+    },
+    {
+      "name" : "Panorama Sample Group",
+      "specification" : "HEIF",
+      "summary" : "Panorama sample group (category: sample group)",
+      "type" : "pano"
+    },
+    {
+      "name" : "Parameter Set",
+      "specification" : "NALu Video",
+      "summary" : "Parameter set (category: sample group)",
+      "type" : "pase"
+    },
+    {
+      "name" : "Pixel Aspect Ratio",
+      "specification" : "ISO",
+      "summary" : "Pixel aspect ratio (handler: Video)",
+      "type" : "pasp"
+    },
+    {
+      "name" : "Pixel Aspect Ratio Sample Grouping",
+      "specification" : "ISO",
+      "summary" : "Pixel Aspect Ratio Sample Grouping (category: sample group)",
+      "type" : "pasr"
+    },
+    {
+      "name" : "Palette Which Maps A Single Component In Index Space To A Multiple- Component Image",
+      "specification" : "JPEG2000",
+      "summary" : "palette which maps a single component in index space to a multiple- component image",
+      "type" : "pclr"
+    },
+    {
+      "name" : "Uncompressed Audio PCM Configuration",
+      "specification" : "ISO-UNCA",
+      "summary" : "Uncompressed audio PCM configuration (handler: Audio)",
+      "type" : "pcmC"
+    },
+    {
+      "name" : "Partial Data",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial Data",
+      "type" : "pdat"
+    },
+    {
+      "name" : "Parametric DRC Coefficients",
+      "specification" : "DRC",
+      "summary" : "Parametric DRC coefficients (handler: Audio)",
+      "type" : "pdc1"
+    },
+    {
+      "name" : "Parametric DRC Instructions",
+      "specification" : "DRC",
+      "summary" : "Parametric DRC instructions (handler: Audio)",
+      "type" : "pdi1"
+    },
+    {
+      "name" : "Progressive Download Information",
+      "specification" : "ISO",
+      "summary" : "Progressive download information",
+      "type" : "pdin"
+    },
+    {
+      "name" : "Media Performer Name",
+      "specification" : "3GPP",
+      "summary" : "Media performer name",
+      "type" : "perf"
+    },
+    {
+      "name" : "Partial File Header",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial File Header",
+      "type" : "pfhd"
+    },
+    {
+      "name" : "Partial File",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial File",
+      "type" : "pfil"
+    },
+    {
+      "name" : "Image Item And Image Sequences",
+      "specification" : "HEIF",
+      "summary" : "Image Item and Image sequences (category: handler)",
+      "type" : "pict"
+    },
+    {
+      "name" : "Protected Interoperable File Format",
+      "specification" : "PIFF",
+      "summary" : "Protected Interoperable File Format",
+      "type" : "piff"
+    },
+    {
+      "name" : "Primary Item Reference",
+      "specification" : "ISO",
+      "summary" : "primary item reference",
+      "type" : "pitm"
+    },
+    {
+      "name" : "Pixel Information",
+      "specification" : "HEIF",
+      "summary" : "Pixel information",
+      "type" : "pixi"
+    },
+    {
+      "name" : "Partial Segment Location",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial Segment Location",
+      "type" : "ploc"
+    },
+    {
+      "name" : "Planar View Array",
+      "specification" : "NALu Video",
+      "summary" : "Planar view array (category: Multiview Reln. Attribute)",
+      "type" : "plvi"
+    },
+    {
+      "name" : "Protected MPEG-2 Transport",
+      "specification" : "ISO",
+      "summary" : "Protected MPEG-2 Transport (handler: Hint)",
+      "type" : "pm2t"
+    },
+    {
+      "name" : "Mixed Partial File",
+      "specification" : "ISO-Partial",
+      "summary" : "Mixed Partial File",
+      "type" : "pmff"
+    },
+    {
+      "name" : "Reserved",
+      "specification" : "ISO",
+      "summary" : "Reserved",
+      "type" : "pnot"
+    },
+    {
+      "name" : "Panasonic Video Intercom",
+      "specification" : "Panasonic Video Intercom",
+      "summary" : "Panasonic Video Intercom",
+      "type" : "pnvi"
+    },
+    {
+      "name" : "Open-ended Scheme Type For Omnidirectional Video Based On A Projection",
+      "specification" : "OMAF",
+      "summary" : "Open-ended scheme type for omnidirectional video based on a projection (category: restricted video scheme)",
+      "type" : "podv"
+    },
+    {
+      "name" : "Playout Track Grouping",
+      "specification" : "V3C-SYS",
+      "summary" : "playout track grouping",
+      "type" : "potg"
+    },
+    {
+      "name" : "Projected Omnidirectional Video",
+      "specification" : "OMAF",
+      "summary" : "projected omnidirectional video",
+      "type" : "povd"
+    },
+    {
+      "name" : "Picture Region Replacement For The Picture-in-picture Functionality",
+      "specification" : "NALu Video",
+      "summary" : "Picture region replacement for the picture-in-picture functionality (category: sample group)",
+      "type" : "pprr"
+    },
+    {
+      "name" : "Predictively Coded Item Reference",
+      "specification" : "HEIF",
+      "summary" : "Predictively coded item reference (category: item ref.)",
+      "type" : "pred"
+    },
+    {
+      "name" : "Pre-Multiplied Item",
+      "specification" : "MIAF",
+      "summary" : "Pre-Multiplied item (category: item ref.)",
+      "type" : "prem"
+    },
+    {
+      "name" : "Profile",
+      "specification" : "NALu Video",
+      "summary" : "Profile (category: Multiview Reln. Attribute)",
+      "type" : "prfl"
+    },
+    {
+      "name" : "Projection Format",
+      "specification" : "OMAF",
+      "summary" : "Projection format",
+      "type" : "prfr"
+    },
+    {
+      "name" : "Producer Reference Time",
+      "specification" : "ISO",
+      "summary" : "Producer reference time",
+      "type" : "prft"
+    },
+    {
+      "name" : "Production Metadata Box",
+      "specification" : "Youtube",
+      "summary" : "Production metadata box",
+      "type" : "prmd"
+    },
+    {
+      "name" : "Production Metadata Reference Box",
+      "specification" : "Youtube",
+      "summary" : "Production metadata reference box (handler: Video)",
+      "type" : "prmr"
+    },
+    {
+      "name" : "Full ICC Color Profile",
+      "specification" : "ISO",
+      "summary" : "Full ICC color profile (category: Color info)",
+      "type" : "prof"
+    },
+    {
+      "name" : "Audio Pre-roll",
+      "specification" : "ISO",
+      "summary" : "Audio pre-roll (category: sample group)",
+      "type" : "prol"
+    },
+    {
+      "name" : "Preselection Grouping",
+      "specification" : "ISO",
+      "summary" : "Preselection grouping",
+      "type" : "prsl"
+    },
+    {
+      "name" : "Protected RTP Reception",
+      "specification" : "ISO",
+      "summary" : "Protected RTP Reception (handler: Hint)",
+      "type" : "prtp"
+    },
+    {
+      "name" : "Partial Segment",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial Segment",
+      "type" : "pseg"
+    },
+    {
+      "name" : "Partial Segment Header",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial Segment Header",
+      "type" : "pshd"
+    },
+    {
+      "name" : "In-band Parameter Set Indication",
+      "specification" : "NALu Video",
+      "summary" : "In-band parameter set indication (category: sample group)",
+      "type" : "pss1"
+    },
+    {
+      "name" : "Protection System Specific Header",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Protection system specific header",
+      "type" : "pssh"
+    },
+    {
+      "name" : "Partial Top Level Entry",
+      "specification" : "ISO-Partial",
+      "summary" : "Partial Top Level Entry",
+      "type" : "ptle"
+    },
+    {
+      "name" : "QuickTime QuickDraw 3D Ttrack Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime QuickDraw 3D ttrack handler (category: handler)",
+      "type" : "qd3d"
+    },
+    {
+      "name" : "Layer Quality Assignments",
+      "specification" : "NALu Video",
+      "summary" : "Layer quality assignments (handler: Video)",
+      "type" : "qlif"
+    },
+    {
+      "name" : "QuickTime",
+      "specification" : "QT",
+      "summary" : "QuickTime",
+      "type" : "qt  "
+    },
+    {
+      "name" : "Restricted ICC Color Profile",
+      "specification" : "ISO",
+      "summary" : "Restricted ICC color profile (category: Color info)",
+      "type" : "rICC"
+    },
+    {
+      "name" : "Random Access Point",
+      "specification" : "ISO",
+      "summary" : "Random access point (category: sample group)",
+      "type" : "rap "
+    },
+    {
+      "name" : "Rate Share",
+      "specification" : "ISO",
+      "summary" : "Rate share (category: sample group)",
+      "type" : "rash"
+    },
+    {
+      "name" : "Uncompressed Audio",
+      "specification" : "MJ2",
+      "summary" : "Uncompressed audio (handler: Audio)",
+      "type" : "raw "
+    },
+    {
+      "name" : "Recommended Viewport Without Indicating A Viewpoint",
+      "specification" : "OMAF",
+      "summary" : "Recommended viewport without indicating a viewpoint (handler: Metadata)",
+      "type" : "rcvp"
+    },
+    {
+      "name" : "Resolved By Extracting An Indicated Subset Of The Referenced VVC Track To Reconstruct A VVC Bitstream",
+      "specification" : "NALu Video",
+      "summary" : "resolved by extracting an indicated subset of the referenced VVC track to reconstruct a VVC bitstream",
+      "type" : "recr"
+    },
+    {
+      "name" : "Name Of The Tape Reel",
+      "specification" : "Apple",
+      "summary" : "Name of the tape reel",
+      "type" : "reel"
+    },
+    {
+      "name" : "Direct Reference Samples List",
+      "specification" : "HEIF",
+      "summary" : "Direct reference samples list (category: sample group)",
+      "type" : "refs"
+    },
+    {
+      "name" : "Combination Brand To Indicate Relative Addressing",
+      "specification" : "ISO",
+      "summary" : "combination brand to indicate relative addressing",
+      "type" : "relo"
+    },
+    {
+      "name" : "Grid Resolution",
+      "specification" : "JPEG2000",
+      "summary" : "grid resolution",
+      "type" : "res "
+    },
+    {
+      "name" : "Restricted Audio",
+      "specification" : "ISO",
+      "summary" : "Restricted Audio (handler: Audio)",
+      "type" : "resa"
+    },
+    {
+      "name" : "The Track Can Be Region-of-interest Scaled.",
+      "specification" : "ISO",
+      "summary" : "The track can be region-of-interest scaled. (category: track sel.)",
+      "type" : "resc"
+    },
+    {
+      "name" : "Default Grid Resolution At Which The Image Should Be Displayed",
+      "specification" : "JPEG2000",
+      "summary" : "default grid resolution at which the image should be displayed",
+      "type" : "resd"
+    },
+    {
+      "name" : "Restricted Video",
+      "specification" : "ISO",
+      "summary" : "Restricted Video (handler: Video)",
+      "type" : "resv"
+    },
+    {
+      "name" : "Region Item",
+      "specification" : "HEIF",
+      "summary" : "Region item",
+      "type" : "rgan"
+    },
+    {
+      "name" : "RGB 24 Bits Packed",
+      "specification" : "UNCV",
+      "summary" : "RGB 24 bits packed",
+      "type" : "rgb3"
+    },
+    {
+      "name" : "RGBA 32bits Packed",
+      "specification" : "UNCV",
+      "summary" : "RGBA 32bits packed",
+      "type" : "rgba"
+    },
+    {
+      "name" : "Restricted Scheme Information Box",
+      "specification" : "ISO",
+      "summary" : "restricted scheme information box",
+      "type" : "rinf"
+    },
+    {
+      "name" : "Representation Index Segment Used To Index MPEG-2 TS Based Media Segments.",
+      "specification" : "DASH",
+      "summary" : "Representation Index Segment used to index MPEG-2 TS based Media Segments.",
+      "type" : "risx"
+    },
+    {
+      "name" : "Relative Location",
+      "specification" : "HEIF",
+      "summary" : "Relative location",
+      "type" : "rloc"
+    },
+    {
+      "name" : "MPEG-2 Transport Reception",
+      "specification" : "ISO",
+      "summary" : "MPEG-2 Transport Reception (handler: Hint)",
+      "type" : "rm2t"
+    },
+    {
+      "name" : "Rendering-related Metadata",
+      "specification" : "Apple",
+      "summary" : "Rendering-related metadata",
+      "type" : "rndr"
+    },
+    {
+      "name" : "Pre\/Post Roll Group",
+      "specification" : "ISO",
+      "summary" : "Pre\/Post roll group (category: sample group)",
+      "type" : "roll"
+    },
+    {
+      "name" : "Sphere Region Configuration",
+      "specification" : "OMAF",
+      "summary" : "sphere region configuration",
+      "type" : "rosc"
+    },
+    {
+      "name" : "Rotation",
+      "specification" : "OMAF",
+      "summary" : "Rotation",
+      "type" : "rotn"
+    },
+    {
+      "name" : "Required Reference Types",
+      "specification" : "HEIF",
+      "summary" : "Required reference types",
+      "type" : "rref"
+    },
+    {
+      "name" : "SVC Rect Region Box",
+      "specification" : "NALu Video",
+      "summary" : "SVC rect region box",
+      "type" : "rrgn"
+    },
+    {
+      "name" : "Rectangular Region Order",
+      "specification" : "NALu Video",
+      "summary" : "Rectangular region order (category: sample group)",
+      "type" : "rror"
+    },
+    {
+      "name" : "RTP Reception",
+      "specification" : "ISO",
+      "summary" : "RTP reception (handler: Hint)",
+      "type" : "rrtp"
+    },
+    {
+      "name" : "Redundant Sample Original Timing",
+      "specification" : "ISO",
+      "summary" : "Redundant Sample Original Timing",
+      "type" : "rsot"
+    },
+    {
+      "name" : "SRTP Reception",
+      "specification" : "ISO",
+      "summary" : "SRTP Reception (handler: Hint)",
+      "type" : "rsrp"
+    },
+    {
+      "name" : "RTCP Reception Hint Track",
+      "specification" : "ISO",
+      "summary" : "RTCP reception hint track (handler: Hint)",
+      "type" : "rtcp"
+    },
+    {
+      "name" : "Real Time Metadata Sample Entry(XAVC Format)",
+      "specification" : "Sony",
+      "summary" : "Real Time Metadata Sample Entry(XAVC Format) (handler: Metadata)",
+      "type" : "rtmd"
+    },
+    {
+      "name" : "Media Rating",
+      "specification" : "3GPP",
+      "summary" : "Media rating",
+      "type" : "rtng"
+    },
+    {
+      "name" : "RTP Hints",
+      "specification" : "ISO",
+      "summary" : "RTP Hints (handler: Hint, objectType: n\/a)",
+      "type" : "rtp "
+    },
+    {
+      "name" : "Rectangular View Array",
+      "specification" : "NALu Video",
+      "summary" : "Rectangular view array (category: Multiview Reln. Attribute)",
+      "type" : "rtvi"
+    },
+    {
+      "name" : "RealVideo Codec 11",
+      "specification" : "RealHD",
+      "summary" : "RealVideo Codec 11 (handler: Video, objectType: 0xB0)",
+      "type" : "rv60"
+    },
+    {
+      "name" : "Recommended Viewport Information",
+      "specification" : "OMAF",
+      "summary" : "recommended viewport information",
+      "type" : "rvif"
+    },
+    {
+      "name" : "Recommended Viewport Concerning One Or More Indicated Viewpoints",
+      "specification" : "OMAF",
+      "summary" : "Recommended viewport concerning one or more indicated viewpoints (handler: Metadata)",
+      "type" : "rvp2"
+    },
+    {
+      "name" : "Region-wise Packing",
+      "specification" : "OMAF",
+      "summary" : "Region-wise packing",
+      "type" : "rwpk"
+    },
+    {
+      "name" : "ITU H.263 Video (3GPP Format)",
+      "specification" : "3GPP",
+      "summary" : "ITU H.263 video (3GPP format) (handler: Video)",
+      "type" : "s263"
+    },
+    {
+      "name" : "HEVC Tile Track",
+      "specification" : "NALu Video",
+      "summary" : "HEVC Tile Track",
+      "type" : "sabt"
+    },
+    {
+      "name" : "SampleAuxiliaryInformationSizesBox With Version 1 And 2",
+      "specification" : "ISO",
+      "summary" : "SampleAuxiliaryInformationSizesBox with version 1 and 2",
+      "type" : "saie"
+    },
+    {
+      "name" : "Sample Auxiliary Information Offsets",
+      "specification" : "ISO",
+      "summary" : "Sample auxiliary information offsets",
+      "type" : "saio"
+    },
+    {
+      "name" : "Sample Auxiliary Information Sizes",
+      "specification" : "ISO",
+      "summary" : "Sample auxiliary information sizes",
+      "type" : "saiz"
+    },
+    {
+      "name" : "Narrowband AMR Voice",
+      "specification" : "3GPP",
+      "summary" : "Narrowband AMR voice (handler: Audio)",
+      "type" : "samr"
+    },
+    {
+      "name" : "Stream Access Point",
+      "specification" : "ISO",
+      "summary" : "Stream access point (category: sample group)",
+      "type" : "sap "
+    },
+    {
+      "name" : "Sample Transform Derived Image Items Combine Input Pixel Values Using Basic Mathematical Operations",
+      "specification" : "AVIF",
+      "summary" : "Sample Transform Derived Image Items combine input pixel values using basic mathematical operations (category: item ref.)",
+      "type" : "sato"
+    },
+    {
+      "name" : "Wideband AMR Voice",
+      "specification" : "3GPP",
+      "summary" : "Wideband AMR voice (handler: Audio)",
+      "type" : "sawb"
+    },
+    {
+      "name" : "Extended AMR-WB (AMR-WB+)",
+      "specification" : "3GPP",
+      "summary" : "Extended AMR-WB (AMR-WB+) (handler: Audio)",
+      "type" : "sawp"
+    },
+    {
+      "name" : "Scalable Base",
+      "specification" : "NALu Video",
+      "summary" : "Scalable base",
+      "type" : "sbas"
+    },
+    {
+      "name" : "Sample To Group Box",
+      "specification" : "ISO",
+      "summary" : "Sample to Group box",
+      "type" : "sbgp"
+    },
+    {
+      "name" : "Sensor Bad Pixels Map",
+      "specification" : "UNCV",
+      "summary" : "Sensor Bad Pixels Map (handler: Video)",
+      "type" : "sbpm"
+    },
+    {
+      "name" : "QuickTime Subtitle Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime Subtitle track handler (category: handler)",
+      "type" : "sbtl"
+    },
+    {
+      "name" : "Text Subtitles",
+      "specification" : "ISO",
+      "summary" : "Text subtitles (handler: Subtitles)",
+      "type" : "sbtt"
+    },
+    {
+      "name" : "Scalable Extraction",
+      "specification" : "NALu Video",
+      "summary" : "Scalable extraction",
+      "type" : "scal"
+    },
+    {
+      "name" : "Name Of The Scene For Which The Clip Was Shot",
+      "specification" : "Apple",
+      "summary" : "Name of the scene for which the clip was shot",
+      "type" : "scen"
+    },
+    {
+      "name" : "Scheme Information Box",
+      "specification" : "ISO",
+      "summary" : "scheme information box",
+      "type" : "schi"
+    },
+    {
+      "name" : "Scheme Type Box",
+      "specification" : "ISO",
+      "summary" : "scheme type box",
+      "type" : "schm"
+    },
+    {
+      "name" : "SVC Scalability Information",
+      "specification" : "NALu Video",
+      "summary" : "SVC Scalability Information (category: sample group)",
+      "type" : "scif"
+    },
+    {
+      "name" : "AVC\/SVC\/MVC Map Groups",
+      "specification" : "NALu Video",
+      "summary" : "AVC\/SVC\/MVC map groups (category: sample group)",
+      "type" : "scnm"
+    },
+    {
+      "name" : "Scramble Scheme Information",
+      "specification" : "ISO",
+      "summary" : "Scramble scheme information (handler: Video)",
+      "type" : "scrb"
+    },
+    {
+      "name" : "Track Differs In Width And\/or Height",
+      "specification" : "ISO",
+      "summary" : "Track differs in width and\/or height (category: track sel.)",
+      "type" : "scsz"
+    },
+    {
+      "name" : "Component Video Track Group",
+      "specification" : "UNCV",
+      "summary" : "Component video track group",
+      "type" : "scvg"
+    },
+    {
+      "name" : "Sample Dependency",
+      "specification" : "NALu Video",
+      "summary" : "Sample dependency",
+      "type" : "sdep"
+    },
+    {
+      "name" : "Reserved For SceneDescriptionStream Header",
+      "specification" : "MP4v2",
+      "summary" : "reserved for SceneDescriptionStream header",
+      "type" : "sdhd"
+    },
+    {
+      "name" : "SDP Information",
+      "specification" : "ISO",
+      "summary" : "SDP information",
+      "type" : "sdp "
+    },
+    {
+      "name" : "SceneDescriptionStream",
+      "specification" : "MP4v2",
+      "summary" : "SceneDescriptionStream (category: handler)",
+      "type" : "sdsm"
+    },
+    {
+      "name" : "Independent And Disposable Samples Box",
+      "specification" : "ISO",
+      "summary" : "Independent and Disposable Samples Box",
+      "type" : "sdtp"
+    },
+    {
+      "name" : "SD Video",
+      "specification" : "SDV",
+      "summary" : "SD Video",
+      "type" : "sdv "
+    },
+    {
+      "name" : "SD Profile Box",
+      "specification" : "SDV",
+      "summary" : "SD Profile Box",
+      "type" : "sdvp"
+    },
+    {
+      "name" : "Identical Sequence Of Samples From An Original Encoding After Separation Into Overlapping Segments Stored Independently. Group Description: 16-byte UUID",
+      "specification" : "Apple",
+      "summary" : "Identical sequence of samples from an original encoding after separation into overlapping segments stored independently. Group description: 16-byte UUID (category: sample group)",
+      "type" : "seam"
+    },
+    {
+      "name" : "File Delivery Session Group",
+      "specification" : "ISO",
+      "summary" : "file delivery session group",
+      "type" : "segr"
+    },
+    {
+      "name" : "Scalability Information",
+      "specification" : "NALu Video",
+      "summary" : "Scalability information (handler: Video)",
+      "type" : "seib"
+    },
+    {
+      "name" : "Sample Encryption Information",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Sample Encryption Information (category: sample group)",
+      "type" : "seig"
+    },
+    {
+      "name" : "SEI Information Box",
+      "specification" : "NALu Video",
+      "summary" : "SEI information box",
+      "type" : "seii"
+    },
+    {
+      "name" : "Sample Specific Encryption Data",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Sample specific encryption data",
+      "type" : "senc"
+    },
+    {
+      "name" : "Video Contents Sony Entertainment Network Provides By Using MP4 File Format",
+      "specification" : "Sony",
+      "summary" : "Video contents Sony Entertainment Network provides by using MP4 file format",
+      "type" : "senv"
+    },
+    {
+      "name" : "EVRC Voice",
+      "specification" : "3GPP2",
+      "summary" : "EVRC Voice (handler: Audio, objectType: 0xA0)",
+      "type" : "sevc"
+    },
+    {
+      "name" : "Enhanced Voice Services (EVS)",
+      "specification" : "3GPP",
+      "summary" : "Enhanced Voice Services (EVS) (handler: Audio)",
+      "type" : "sevs"
+    },
+    {
+      "name" : "Sample Group Definition Box",
+      "specification" : "ISO",
+      "summary" : "Sample group definition box",
+      "type" : "sgpd"
+    },
+    {
+      "name" : "SHA-1 Checksum As Specified In RFC 3174",
+      "specification" : "ISO-Partial",
+      "summary" : "SHA-1 checksum as specified in RFC 3174",
+      "type" : "sha1"
+    },
+    {
+      "name" : "Name That Identifies The Shot",
+      "specification" : "Apple",
+      "summary" : "Name that identifies the shot",
+      "type" : "shot"
+    },
+    {
+      "name" : "Reference To A Shadow Sync Sample Track",
+      "specification" : "OMAF",
+      "summary" : "reference to a shadow sync sample track",
+      "type" : "shsc"
+    },
+    {
+      "name" : "Segment Index Box",
+      "specification" : "ISO",
+      "summary" : "Segment Index Box",
+      "type" : "sidx"
+    },
+    {
+      "name" : "Scheme ID List Box",
+      "specification" : "Event Message",
+      "summary" : "Scheme ID list Box (handler: Metadata)",
+      "type" : "silb"
+    },
+    {
+      "name" : "Media Segment Conforming To The Sub-Indexed Media Segment Format Type For ISO Base Media File Format.",
+      "specification" : "DASH",
+      "summary" : "Media Segment conforming to the Sub-Indexed Media Segment format type for ISO base media file format.",
+      "type" : "sims"
+    },
+    {
+      "name" : "Protection Scheme Information Box",
+      "specification" : "ISO",
+      "summary" : "protection scheme information box",
+      "type" : "sinf"
+    },
+    {
+      "name" : "Single Index Segment Used To Index MPEG-2 TS Based Media Segments.",
+      "specification" : "DASH",
+      "summary" : "Single Index Segment used to index MPEG-2 TS based Media Segments.",
+      "type" : "sisx"
+    },
+    {
+      "name" : "HEVC-based Simple Tiling OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "HEVC-based simple tiling OMAF video profile",
+      "type" : "siti"
+    },
+    {
+      "name" : "VVC-based Simple Tiling OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "VVC-based simple tiling OMAF video profile",
+      "type" : "sitv"
+    },
+    {
+      "name" : "Free Space",
+      "specification" : "ISO",
+      "summary" : "free space",
+      "type" : "skip"
+    },
+    {
+      "name" : "Key Management Messages",
+      "specification" : "DVB",
+      "summary" : "Key Management Messages (category: handler)",
+      "type" : "skmm"
+    },
+    {
+      "name" : "Dynamic Metadata For Single Layer SDR-compatible HDR Video Streams",
+      "specification" : "SL-HDR",
+      "summary" : "Dynamic metadata for Single Layer SDR-compatible HDR video streams",
+      "type" : "slh1"
+    },
+    {
+      "name" : "Dynamic Metadata For Single Layer PQ-based HDR Video Streams",
+      "specification" : "SL-HDR",
+      "summary" : "Dynamic metadata for Single Layer PQ-based HDR video streams",
+      "type" : "slh2"
+    },
+    {
+      "name" : "Dynamic Metadata For Single Layer HLG-based HDR Video Streams",
+      "specification" : "SL-HDR",
+      "summary" : "Dynamic metadata for Single Layer HLG-based HDR video streams",
+      "type" : "slh3"
+    },
+    {
+      "name" : "Slideshow Entity Group",
+      "specification" : "HEIF",
+      "summary" : "Slideshow entity group",
+      "type" : "slid"
+    },
+    {
+      "name" : "Serial Number Of The Camera",
+      "specification" : "Apple",
+      "summary" : "Serial number of the camera",
+      "type" : "slno"
+    },
+    {
+      "name" : "MPEG-2 Transport Server",
+      "specification" : "ISO",
+      "summary" : "MPEG-2 Transport Server (handler: Hint)",
+      "type" : "sm2t"
+    },
+    {
+      "name" : "Sound Media Header, Overall Information (sound Track Only)",
+      "specification" : "ISO",
+      "summary" : "sound media header, overall information (sound track only)",
+      "type" : "smhd"
+    },
+    {
+      "name" : "Samsung Video Metadata Handler",
+      "specification" : "Samsung",
+      "summary" : "Samsung Video Metadata Handler (category: handler)",
+      "type" : "smhr"
+    },
+    {
+      "name" : "Sequence Number Identified Media Data",
+      "specification" : "ISO",
+      "summary" : "sequence number identified media data (category: Data reference)",
+      "type" : "snim"
+    },
+    {
+      "name" : "Sensor Non-Uniformity Correction",
+      "specification" : "UNCV",
+      "summary" : "Sensor Non-Uniformity Correction (handler: Video)",
+      "type" : "snuc"
+    },
+    {
+      "name" : "A Group Of VVC Subpicture Tracks Where The VCL NAL Units Of The Time-aligned Samples Have The Same NAL Unit Type",
+      "specification" : "NALu Video",
+      "summary" : "a group of VVC subpicture tracks where the VCL NAL units of the time-aligned samples have the same NAL unit type",
+      "type" : "snut"
+    },
+    {
+      "name" : "Audio",
+      "specification" : "ISO",
+      "summary" : "Audio (category: handler)",
+      "type" : "soun"
+    },
+    {
+      "name" : "VVC Subpicture ID",
+      "specification" : "NALu Video",
+      "summary" : "VVC subpicture ID (category: sample group)",
+      "type" : "spid"
+    },
+    {
+      "name" : "Sample Packing Information Box",
+      "specification" : "ISO",
+      "summary" : "Sample packing information box",
+      "type" : "spki"
+    },
+    {
+      "name" : "Sample-packed Track That May Contain Packed Samples (a Single Sample May Contain More Than One Sample Of An Original Track)",
+      "specification" : "ISO",
+      "summary" : "Sample-packed track that may contain packed samples (a single sample may contain more than one sample of an original track) (category: restricted video scheme)",
+      "type" : "spkt"
+    },
+    {
+      "name" : "VVC Subpicture Level Information",
+      "specification" : "NALu Video",
+      "summary" : "VVC subpicture level information (category: sample group)",
+      "type" : "spli"
+    },
+    {
+      "name" : "Split Transition Effect",
+      "specification" : "HEIF",
+      "summary" : "Split transition effect",
+      "type" : "splt"
+    },
+    {
+      "name" : "Polarization Pattern Definition",
+      "specification" : "UNCV",
+      "summary" : "Polarization Pattern Definition (handler: Video)",
+      "type" : "splz"
+    },
+    {
+      "name" : "VVC Subpicture Order",
+      "specification" : "NALu Video",
+      "summary" : "VVC subpicture order (category: sample group)",
+      "type" : "spor"
+    },
+    {
+      "name" : "Sub-picture Region",
+      "specification" : "OMAF",
+      "summary" : "sub-picture region",
+      "type" : "sprg"
+    },
+    {
+      "name" : "QuickTime Sprite Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime Sprite track handler (category: handler)",
+      "type" : "sprt"
+    },
+    {
+      "name" : "The Track Can Be Spatially Scaled.",
+      "specification" : "ISO",
+      "summary" : "The track can be spatially scaled. (category: track sel.)",
+      "type" : "spsc"
+    },
+    {
+      "name" : "Spherical View Array",
+      "specification" : "NALu Video",
+      "summary" : "Spherical view array (category: Multiview Reln. Attribute)",
+      "type" : "spvi"
+    },
+    {
+      "name" : "13K Voice",
+      "specification" : "3GPP2",
+      "summary" : "13K Voice (handler: Audio, objectType: 0xE1)",
+      "type" : "sqcp"
+    },
+    {
+      "name" : "Sampling Rate",
+      "specification" : "ISO",
+      "summary" : "Sampling rate (handler: Audio)",
+      "type" : "srat"
+    },
+    {
+      "name" : "System Renewability Message",
+      "specification" : "DVB",
+      "summary" : "System Renewability Message",
+      "type" : "srmb"
+    },
+    {
+      "name" : "System Renewability Message Container",
+      "specification" : "DVB",
+      "summary" : "System Renewability Message container",
+      "type" : "srmc"
+    },
+    {
+      "name" : "STRP Process",
+      "specification" : "ISO",
+      "summary" : "STRP Process",
+      "type" : "srpp"
+    },
+    {
+      "name" : "Sphere Region Quality Ranking",
+      "specification" : "OMAF",
+      "summary" : "sphere region quality ranking",
+      "type" : "srqr"
+    },
+    {
+      "name" : "SRTP Hints",
+      "specification" : "ISO",
+      "summary" : "SRTP Hints (handler: Hint, objectType: n\/a)",
+      "type" : "srtp"
+    },
+    {
+      "name" : "Sub-sample Index",
+      "specification" : "ISO",
+      "summary" : "Sub-sample index",
+      "type" : "ssix"
+    },
+    {
+      "name" : "Suggested Time Display Duraton",
+      "specification" : "HEIF",
+      "summary" : "Suggested time display duraton",
+      "type" : "ssld"
+    },
+    {
+      "name" : "SMV Voice",
+      "specification" : "3GPP2",
+      "summary" : "SMV Voice (handler: Audio, objectType: 0xA1)",
+      "type" : "ssmv"
+    },
+    {
+      "name" : "Sub-sample Reference Table Box",
+      "specification" : "ISO",
+      "summary" : "Sub-sample Reference Table Box",
+      "type" : "ssrt"
+    },
+    {
+      "name" : "Subsegment Index Segment Used To Index MPEG-2 TS Based Media Segments.",
+      "specification" : "DASH",
+      "summary" : "Subsegment Index Segment used to index MPEG-2 TS based Media Segments.",
+      "type" : "ssss"
+    },
+    {
+      "name" : "SVC Sub Track Layer Box",
+      "specification" : "NALu Video",
+      "summary" : "SVC sub track layer box",
+      "type" : "sstl"
+    },
+    {
+      "name" : "Sample Table Box, Container For The Time\/space Map",
+      "specification" : "ISO",
+      "summary" : "sample table box, container for the time\/space map",
+      "type" : "stbl"
+    },
+    {
+      "name" : "Chunk Offset, Partial Data-offset Information",
+      "specification" : "ISO",
+      "summary" : "chunk offset, partial data-offset information",
+      "type" : "stco"
+    },
+    {
+      "name" : "SRTCP Reception Hint Track",
+      "specification" : "ISO",
+      "summary" : "SRTCP reception hint track (handler: Hint)",
+      "type" : "stcp"
+    },
+    {
+      "name" : "Sample Degradation Priority",
+      "specification" : "ISO",
+      "summary" : "sample degradation priority",
+      "type" : "stdp"
+    },
+    {
+      "name" : "Stereo Pair Track Grouping",
+      "specification" : "ISO",
+      "summary" : "stereo pair track grouping",
+      "type" : "ster"
+    },
+    {
+      "name" : "Subtitle Media Header Box",
+      "specification" : "ISO",
+      "summary" : "Subtitle Media Header Box",
+      "type" : "sthd"
+    },
+    {
+      "name" : "Metadata For ERP (equirectangular Projection) Regions",
+      "specification" : "OMAF",
+      "summary" : "Metadata for ERP (equirectangular projection) regions (handler: Metadata)",
+      "type" : "stmd"
+    },
+    {
+      "name" : "MVC Sub Track Multiview Group Box",
+      "specification" : "NALu Video",
+      "summary" : "MVC sub track multiview group box",
+      "type" : "stmg"
+    },
+    {
+      "name" : "SampleToMetadataItemEntry",
+      "specification" : "ISO",
+      "summary" : "SampleToMetadataItemEntry (category: sample group)",
+      "type" : "stmi"
+    },
+    {
+      "name" : "Suggested Transition Period",
+      "specification" : "HEIF",
+      "summary" : "Suggested transition period",
+      "type" : "stpe"
+    },
+    {
+      "name" : "Subtitles (Timed Text)",
+      "specification" : "ISO",
+      "summary" : "Subtitles (Timed Text) (handler: Subtitles)",
+      "type" : "stpp"
+    },
+    {
+      "name" : "Sub-track Definition",
+      "specification" : "ISO",
+      "summary" : "Sub-track definition",
+      "type" : "strd"
+    },
+    {
+      "name" : "Sub-track Information",
+      "specification" : "ISO",
+      "summary" : "Sub-track information",
+      "type" : "stri"
+    },
+    {
+      "name" : "Sub Track Information",
+      "specification" : "ISO",
+      "summary" : "Sub track information",
+      "type" : "strk"
+    },
+    {
+      "name" : "QuickTime Streaming Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime Streaming track handler (category: handler)",
+      "type" : "strm"
+    },
+    {
+      "name" : "Step-wise Temporal Layer",
+      "specification" : "NALu Video",
+      "summary" : "Step-wise Temporal Layer (category: sample group)",
+      "type" : "stsa"
+    },
+    {
+      "name" : "Sample-to-chunk, Partial Data-offset Information",
+      "specification" : "ISO",
+      "summary" : "sample-to-chunk, partial data-offset information",
+      "type" : "stsc"
+    },
+    {
+      "name" : "Sample Descriptions (codec Types, Initialization Etc.)",
+      "specification" : "ISO",
+      "summary" : "sample descriptions (codec types, initialization etc.)",
+      "type" : "stsd"
+    },
+    {
+      "name" : "Sub-track Sample Grouping",
+      "specification" : "ISO",
+      "summary" : "Sub-track sample grouping",
+      "type" : "stsg"
+    },
+    {
+      "name" : "Shadow Sync Sample Table",
+      "specification" : "ISO",
+      "summary" : "shadow sync sample table",
+      "type" : "stsh"
+    },
+    {
+      "name" : "Sync Sample Table (random Access Points)",
+      "specification" : "ISO",
+      "summary" : "sync sample table (random access points)",
+      "type" : "stss"
+    },
+    {
+      "name" : "Sample Sizes (framing)",
+      "specification" : "ISO",
+      "summary" : "sample sizes (framing)",
+      "type" : "stsz"
+    },
+    {
+      "name" : "Sub Track Tier Box",
+      "specification" : "NALu Video",
+      "summary" : "Sub track tier box",
+      "type" : "stti"
+    },
+    {
+      "name" : "(decoding) Time-to-sample",
+      "specification" : "ISO",
+      "summary" : "(decoding) time-to-sample",
+      "type" : "stts"
+    },
+    {
+      "name" : "Tile Video Track Group",
+      "specification" : "UNCV",
+      "summary" : "Tile video track group",
+      "type" : "stvg"
+    },
+    {
+      "name" : "Stereo Video Restricted Scheme",
+      "specification" : "ISO",
+      "summary" : "Stereo video restricted scheme (category: restricted video scheme)",
+      "type" : "stvi"
+    },
+    {
+      "name" : "Simple Timed Text",
+      "specification" : "ISO",
+      "summary" : "Simple timed text (handler: Text)",
+      "type" : "stxt"
+    },
+    {
+      "name" : "Segment Type Box",
+      "specification" : "ISO",
+      "summary" : "Segment Type Box",
+      "type" : "styp"
+    },
+    {
+      "name" : "Compact Sample Sizes (framing)",
+      "specification" : "ISO",
+      "summary" : "compact sample sizes (framing)",
+      "type" : "stz2"
+    },
+    {
+      "name" : "The Referenced VVC Subpicture Tracks Or 'alte' Track Groups Of VVC Subpicture Tracks Are Used To Reconstruct A VVC Bitstream",
+      "specification" : "NALu Video",
+      "summary" : "the referenced VVC subpicture tracks or 'alte' track groups of VVC subpicture tracks are used to reconstruct a VVC bitstream",
+      "type" : "subp"
+    },
+    {
+      "name" : "Subsample Information",
+      "specification" : "HEIF",
+      "summary" : "Subsample information",
+      "type" : "subs"
+    },
+    {
+      "name" : "Subtitles",
+      "specification" : "ISO",
+      "summary" : "Subtitles (category: handler)",
+      "type" : "subt"
+    },
+    {
+      "name" : "Signer Identity Information",
+      "specification" : "ONVIF",
+      "summary" : "signer identity information",
+      "type" : "suep"
+    },
+    {
+      "name" : "VVC Subpicture Layout",
+      "specification" : "NALu Video",
+      "summary" : "VVC subpicture layout (category: sample group)",
+      "type" : "sulm"
+    },
+    {
+      "name" : "Supplemental Surveillance Meta Information",
+      "specification" : "MPEG-VSAF",
+      "summary" : "supplemental surveillance meta information",
+      "type" : "sumi"
+    },
+    {
+      "name" : "The Referenced Tracks Provide Supplementary Video To Achieve Picture-in-picture Functionality",
+      "specification" : "NALu Video",
+      "summary" : "The referenced tracks provide supplementary video to achieve picture-in-picture functionality",
+      "type" : "supm"
+    },
+    {
+      "name" : "Source URL",
+      "specification" : "ISO-Partial",
+      "summary" : "Source URL",
+      "type" : "surl"
+    },
+    {
+      "name" : "Scalable Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Scalable Video Coding (handler: Video)",
+      "type" : "svc1"
+    },
+    {
+      "name" : "Scalable Video Coding",
+      "specification" : "NALu Video",
+      "summary" : "Scalable Video Coding (handler: Video)",
+      "type" : "svc2"
+    },
+    {
+      "name" : "SVC Configuration",
+      "specification" : "NALu Video",
+      "summary" : "SVC configuration (handler: Video)",
+      "type" : "svcC"
+    },
+    {
+      "name" : "SVC Metadata",
+      "specification" : "NALu Video",
+      "summary" : "SVC metadata (handler: Metadata)",
+      "type" : "svcM"
+    },
+    {
+      "name" : "SVC Priority Assignments",
+      "specification" : "NALu Video",
+      "summary" : "SVC priority assignments (handler: Video)",
+      "type" : "svcP"
+    },
+    {
+      "name" : "SVC Dependency Range",
+      "specification" : "NALu Video",
+      "summary" : "SVC dependency range",
+      "type" : "svdr"
+    },
+    {
+      "name" : "AES-CTR Content Sensitive Encryption",
+      "specification" : "ISO Common Encryption",
+      "summary" : "AES-CTR content sensitive encryption (category: protection scheme)",
+      "type" : "sve1"
+    },
+    {
+      "name" : "Initial Parameter Sets Box For Tiers",
+      "specification" : "NALu Video",
+      "summary" : "Initial parameter sets box for tiers",
+      "type" : "svip"
+    },
+    {
+      "name" : "SVC Information Configuration",
+      "specification" : "NALu Video",
+      "summary" : "SVC information configuration (handler: Metadata)",
+      "type" : "svmC"
+    },
+    {
+      "name" : "Priority Range",
+      "specification" : "NALu Video",
+      "summary" : "Priority range",
+      "type" : "svpr"
+    },
+    {
+      "name" : "AVC Switch From",
+      "specification" : "NALu Video",
+      "summary" : "AVC Switch from",
+      "type" : "swfr"
+    },
+    {
+      "name" : "Object Switch Alternatives Grouping",
+      "specification" : "V3C-SYS",
+      "summary" : "Object switch alternatives grouping",
+      "type" : "swpc"
+    },
+    {
+      "name" : "Name And Version Number Of The Software That Generated This Movie",
+      "specification" : "Apple",
+      "summary" : "Name and version number of the software that generated this movie",
+      "type" : "swre"
+    },
+    {
+      "name" : "Multiview Group Relation",
+      "specification" : "NALu Video",
+      "summary" : "Multiview Group Relation",
+      "type" : "swtc"
+    },
+    {
+      "name" : "The Track Differs In Switchable Tracks Hierarchy ID Defined In The VVC Switchable Tracks Entity Group",
+      "specification" : "NALu Video",
+      "summary" : "The track differs in switchable tracks hierarchy ID defined in the VVC switchable tracks entity group (category: track sel.)",
+      "type" : "swtk"
+    },
+    {
+      "name" : "AVC Switch To",
+      "specification" : "NALu Video",
+      "summary" : "AVC Switch to",
+      "type" : "swto"
+    },
+    {
+      "name" : "Sync Sample Groups",
+      "specification" : "NALu Video",
+      "summary" : "Sync sample groups (category: sample group)",
+      "type" : "sync"
+    },
+    {
+      "name" : "HEVC Tile Track Base Item Reference",
+      "specification" : "HEIF",
+      "summary" : "HEVC Tile track base item reference (category: item ref.)",
+      "type" : "tbas"
+    },
+    {
+      "name" : "64 Bit Timecode Samples",
+      "specification" : "Apple",
+      "summary" : "64 bit timecode samples (handler: Timecode)",
+      "type" : "tc64"
+    },
+    {
+      "name" : "Temporal Level",
+      "specification" : "ISO",
+      "summary" : "Temporal Level (category: sample group)",
+      "type" : "tele"
+    },
+    {
+      "name" : "Track Encryption",
+      "specification" : "ISO Common Encryption",
+      "summary" : "Track Encryption",
+      "type" : "tenc"
+    },
+    {
+      "name" : "The Track Can Be Temporally Scaled.",
+      "specification" : "ISO",
+      "summary" : "The track can be temporally scaled. (category: track sel.)",
+      "type" : "tesc"
+    },
+    {
+      "name" : "Text",
+      "specification" : "3GPP",
+      "summary" : "Text (category: handler)",
+      "type" : "text"
+    },
+    {
+      "name" : "Track Fragment Adjustment Box",
+      "specification" : "3GPP",
+      "summary" : "Track fragment adjustment box",
+      "type" : "tfad"
+    },
+    {
+      "name" : "Track Fragment Decode Time",
+      "specification" : "ISO",
+      "summary" : "Track fragment decode time",
+      "type" : "tfdt"
+    },
+    {
+      "name" : "Track Fragment Header",
+      "specification" : "ISO",
+      "summary" : "Track fragment header",
+      "type" : "tfhd"
+    },
+    {
+      "name" : "Track Fragment Media Adjustment Box",
+      "specification" : "3GPP",
+      "summary" : "Track fragment media adjustment box",
+      "type" : "tfma"
+    },
+    {
+      "name" : "Track Fragment Radom Access",
+      "specification" : "ISO",
+      "summary" : "Track fragment radom access",
+      "type" : "tfra"
+    },
+    {
+      "name" : "Thumbnail Image Item Reference",
+      "specification" : "HEIF",
+      "summary" : "Thumbnail image item reference (category: item ref.)",
+      "type" : "thmb"
+    },
+    {
+      "name" : "Tier Bit Rate",
+      "specification" : "NALu Video",
+      "summary" : "Tier Bit rate",
+      "type" : "tibr"
+    },
+    {
+      "name" : "Model Tie-point",
+      "specification" : "OGC 24-038",
+      "summary" : "Model tie-point",
+      "type" : "tiep"
+    },
+    {
+      "name" : "The Sub-track Is Spatial Part Or Tile Of The Track.",
+      "specification" : "NALu Video",
+      "summary" : "The sub-track is spatial part or tile of the track. (category: track sel.)",
+      "type" : "tile"
+    },
+    {
+      "name" : "Tier Information",
+      "specification" : "NALu Video",
+      "summary" : "Tier Information",
+      "type" : "tiri"
+    },
+    {
+      "name" : "Media Title",
+      "specification" : "3GPP",
+      "summary" : "Media title",
+      "type" : "titl"
+    },
+    {
+      "flags" : "000007",
+      "name" : "Track Header, Overall Information About The Track",
+      "specification" : "ISO\/IEC 14496-12",
+      "summary" : "Defines the characteristics of a track, including ID, duration, and display parameters.",
+      "type" : "tkhd",
+      "version" : 0
+    },
+    {
+      "name" : "Track Loudness Base",
+      "specification" : "ISO",
+      "summary" : "Track loudness base",
+      "type" : "tlou"
+    },
+    {
+      "name" : "32 Bit Timecode Samples",
+      "specification" : "Apple",
+      "summary" : "32 bit timecode samples (handler: Timecode)",
+      "type" : "tmcd"
+    },
+    {
+      "name" : "Tile Mesh Sample Grouping",
+      "specification" : "OMAF",
+      "summary" : "Tile mesh sample grouping (category: sample group)",
+      "type" : "tmsh"
+    },
+    {
+      "name" : "Layered HEVC Target Output Layer Set Property",
+      "specification" : "HEIF",
+      "summary" : "Layered HEVC Target output layer set property",
+      "type" : "tols"
+    },
+    {
+      "name" : "Track Fragment",
+      "specification" : "ISO",
+      "summary" : "Track fragment",
+      "type" : "traf"
+    },
+    {
+      "name" : "Container For An Individual Track Or Stream",
+      "specification" : "ISO\/IEC 14496-12",
+      "summary" : "Container describing a single track within the presentation.",
+      "type" : "trak"
+    },
+    {
+      "name" : "SVC Lightweight Transcoding",
+      "specification" : "NALu Video",
+      "summary" : "SVC lightweight transcoding",
+      "type" : "tran"
+    },
+    {
+      "name" : "Track Reference Container",
+      "specification" : "ISO",
+      "summary" : "track reference container",
+      "type" : "tref"
+    },
+    {
+      "name" : "Track Extension Properties",
+      "specification" : "ISO",
+      "summary" : "track extension properties",
+      "type" : "trep"
+    },
+    {
+      "name" : "Track Extends Defaults",
+      "specification" : "ISO",
+      "summary" : "track extends defaults",
+      "type" : "trex"
+    },
+    {
+      "name" : "Track Grouping Information",
+      "specification" : "ISO",
+      "summary" : "Track grouping information",
+      "type" : "trgr"
+    },
+    {
+      "name" : "Rectangular Region Group",
+      "specification" : "NALu Video",
+      "summary" : "Rectangular region group (category: sample group)",
+      "type" : "trif"
+    },
+    {
+      "name" : "Facilitates Random Access And Trick Play Modes",
+      "specification" : "DECE",
+      "summary" : "Facilitates random access and trick play modes",
+      "type" : "trik"
+    },
+    {
+      "name" : "Track Fragment Run",
+      "specification" : "ISO",
+      "summary" : "track fragment run",
+      "type" : "trun"
+    },
+    {
+      "name" : "Temporal Sub-Layer Access",
+      "specification" : "NALu Video",
+      "summary" : "Temporal Sub-Layer access (category: sample group)",
+      "type" : "tsas"
+    },
+    {
+      "name" : "Temporal Layer",
+      "specification" : "NALu Video",
+      "summary" : "Temporal Layer (category: sample group)",
+      "type" : "tscl"
+    },
+    {
+      "name" : "Track Selection",
+      "specification" : "ISO",
+      "summary" : "Track selection",
+      "type" : "tsel"
+    },
+    {
+      "name" : "TileSubTrackGroupBox",
+      "specification" : "NALu Video",
+      "summary" : "TileSubTrackGroupBox",
+      "type" : "tstb"
+    },
+    {
+      "name" : "Time-synchronized Capture Entity Group",
+      "specification" : "HEIF",
+      "summary" : "Time-synchronized capture entity group",
+      "type" : "tsyn"
+    },
+    {
+      "name" : "OMAF IMSC1 Timed Text Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF IMSC1 timed text profile",
+      "type" : "ttml"
+    },
+    {
+      "name" : "Sphere Location For Timed Text",
+      "specification" : "OMAF",
+      "summary" : "Sphere location for timed text (handler: Metadata)",
+      "type" : "ttsl"
+    },
+    {
+      "name" : "OMAF WebVTT Timed Text Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF WebVTT timed text profile",
+      "type" : "ttwv"
+    },
+    {
+      "name" : "Track Type And Compatibility",
+      "specification" : "ISO",
+      "summary" : "track type and compatibility",
+      "type" : "ttyp"
+    },
+    {
+      "name" : "QuickTime Tween Track Handler",
+      "specification" : "Apple",
+      "summary" : "QuickTime Tween track handler (category: handler)",
+      "type" : "twen"
+    },
+    {
+      "name" : "Uncompressed 16-bit Audio",
+      "specification" : "MJ2",
+      "summary" : "Uncompressed 16-bit audio (handler: Audio)",
+      "type" : "twos"
+    },
+    {
+      "name" : "Timed Text Stream",
+      "specification" : "3GPP",
+      "summary" : "Timed Text stream (handler: Text)",
+      "type" : "tx3g"
+    },
+    {
+      "name" : "Text Stream Configuration",
+      "specification" : "ISO",
+      "summary" : "Text stream configuration (handler: Text)",
+      "type" : "txtC"
+    },
+    {
+      "name" : "Type And-combination",
+      "specification" : "ISO",
+      "summary" : "type and-combination",
+      "type" : "tyco"
+    },
+    {
+      "name" : "Basic DRC Coefficients",
+      "specification" : "DRC",
+      "summary" : "Basic DRC coefficients (handler: Audio)",
+      "type" : "udc1"
+    },
+    {
+      "name" : "Unified DRC Coefficients",
+      "specification" : "DRC",
+      "summary" : "Unified DRC coefficients (handler: Audio)",
+      "type" : "udc2"
+    },
+    {
+      "name" : "User Description",
+      "specification" : "HEIF",
+      "summary" : "User description",
+      "type" : "udes"
+    },
+    {
+      "name" : "Unified DRC Configuration Extension",
+      "specification" : "DRC",
+      "summary" : "Unified DRC configuration extension (handler: Audio)",
+      "type" : "udex"
+    },
+    {
+      "name" : "Basic DRC Instructions",
+      "specification" : "DRC",
+      "summary" : "Basic DRC instructions (handler: Audio)",
+      "type" : "udi1"
+    },
+    {
+      "name" : "Unified DRC Instructions",
+      "specification" : "DRC",
+      "summary" : "Unified DRC instructions (handler: Audio)",
+      "type" : "udi2"
+    },
+    {
+      "name" : "User-data",
+      "specification" : "ISO",
+      "summary" : "user-data",
+      "type" : "udta"
+    },
+    {
+      "name" : "Equalization Coefficients",
+      "specification" : "DRC",
+      "summary" : "Equalization coefficients (handler: Audio)",
+      "type" : "ueqc"
+    },
+    {
+      "name" : "Equalization Instructions",
+      "specification" : "DRC",
+      "summary" : "Equalization instructions (handler: Audio)",
+      "type" : "ueqi"
+    },
+    {
+      "name" : "Unconstrained HEVC-based Viewport-independent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "Unconstrained HEVC-based viewport-independent OMAF video profile",
+      "type" : "uhvi"
+    },
+    {
+      "name" : "A Tool By Which A Vendor May Provide Access To Additional Information Associated With A UUID",
+      "specification" : "JPEG2000",
+      "summary" : "a tool by which a vendor may provide access to additional information associated with a UUID",
+      "type" : "uinf"
+    },
+    {
+      "name" : "Samples Have Been Compressed Using ULaw 2:1.",
+      "specification" : "QT",
+      "summary" : "Samples have been compressed using uLaw 2:1. (handler: Audio)",
+      "type" : "ulaw"
+    },
+    {
+      "name" : "A List Of UUID’s",
+      "specification" : "JPEG2000",
+      "summary" : "a list of UUID’s",
+      "type" : "ulst"
+    },
+    {
+      "name" : "Uncompressed Frame Configuration",
+      "specification" : "UNCV",
+      "summary" : "Uncompressed Frame Configuration (handler: Video)",
+      "type" : "uncC"
+    },
+    {
+      "name" : "Uncompressed Image Item",
+      "specification" : "UNCV",
+      "summary" : "Uncompressed Image Item",
+      "type" : "unci"
+    },
+    {
+      "name" : "Uncompressed Video",
+      "specification" : "UNCV",
+      "summary" : "Uncompressed Video (handler: Video)",
+      "type" : "uncv"
+    },
+    {
+      "name" : "Dynamic Range Control (DRC) Data",
+      "specification" : "DRC",
+      "summary" : "Dynamic Range Control (DRC) data (handler: Metadata)",
+      "type" : "unid"
+    },
+    {
+      "name" : "Unified Identifiers",
+      "specification" : "ISO",
+      "summary" : "Unified identifiers",
+      "type" : "unif"
+    },
+    {
+      "name" : "User 'star' Rating Of The Media",
+      "specification" : "3GPP",
+      "summary" : "User 'star' rating of the media",
+      "type" : "urat"
+    },
+    {
+      "name" : "URI Identified Metadata",
+      "specification" : "DVB",
+      "summary" : "URI identified metadata (category: handler)",
+      "type" : "uri "
+    },
+    {
+      "name" : "URI Information",
+      "specification" : "ISO",
+      "summary" : "URI Information (handler: Metadata)",
+      "type" : "uriI"
+    },
+    {
+      "name" : "Binary Timed Metadata Identified By URI",
+      "specification" : "ISO",
+      "summary" : "Binary timed metadata identified by URI (handler: Metadata)",
+      "type" : "urim"
+    },
+    {
+      "name" : "URL Data Location",
+      "specification" : "ISO",
+      "summary" : "URL data location (category: Data reference)",
+      "type" : "url "
+    },
+    {
+      "name" : "URN Data Location",
+      "specification" : "ISO",
+      "summary" : "URN data location (category: Data reference)",
+      "type" : "urn "
+    },
+    {
+      "name" : "KLV Sample Entry",
+      "specification" : "SMPTE ST 336",
+      "summary" : "Carries SMPTE KLV sample metadata using a registered UUID container.",
+      "type" : "uuid",
+      "uuid" : "D4807EF2-CA39-4695-8E54-26CB9E46A79F"
+    },
+    {
+      "name" : "UltraViolet File Brand – Conforming To The DECE Common File Format Spec, Annex E.",
+      "specification" : "DECE",
+      "summary" : "UltraViolet file brand – conforming to the DECE Common File Format spec, Annex E.",
+      "type" : "uvvu"
+    },
+    {
+      "name" : "10 Bit Per Component YUV 4:2:2. 12 10-bit Unsigned Components Are Packed Into Four 32-bit Little-endian Words",
+      "specification" : "Apple",
+      "summary" : "10 bit per component YUV 4:2:2. 12 10-bit unsigned components are packed into four 32-bit little-endian words",
+      "type" : "v210"
+    },
+    {
+      "name" : "10,12,14,16 Bit Per Component YUV 4:2:2. Packed Cb Y0 Cr Y1 (each N-bit Component Is Left Justified In A 16 Bit Little-endian Word)",
+      "specification" : "Apple",
+      "summary" : "10,12,14,16 bit per component YUV 4:2:2. Packed Cb Y0 Cr Y1 (each n-bit component is left justified in a 16 bit little-endian word)",
+      "type" : "v216"
+    },
+    {
+      "name" : "8 Bit Per Component YUV 4:4:4. Packed Cr Y Cb",
+      "specification" : "Apple",
+      "summary" : "8 bit per component YUV 4:4:4. Packed Cr Y Cb",
+      "type" : "v308"
+    },
+    {
+      "name" : "V3C Atlas Track With Atlas Parameter Sets Only In Sample Entries",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas track with atlas parameter sets only in sample entries (handler: Volumetric visual media)",
+      "type" : "v3a1"
+    },
+    {
+      "name" : "V3C Atlas Track With Atlas Parameter Sets In Sample Entries Or Samples",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas track with atlas parameter sets in sample entries or samples (handler: Volumetric visual media)",
+      "type" : "v3ag"
+    },
+    {
+      "name" : "V3C Atlas Track With A Single Atlas And Atlas Parameter Sets Only In Sample Entries",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas track with a single atlas and atlas parameter sets only in sample entries (handler: Volumetric visual media)",
+      "type" : "v3c1"
+    },
+    {
+      "name" : "V3C Configuration",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C Configuration (handler: Volumetric visual media)",
+      "type" : "v3cC"
+    },
+    {
+      "name" : "V3C Atlas Base Track With Common Atlas Data",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas base track with common atlas data (handler: Volumetric visual media)",
+      "type" : "v3cb"
+    },
+    {
+      "name" : "V3C Atlas Track With A Single Atlas And Atlas Parameter Sets In Sample Entries Or Samples",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas track with a single atlas and atlas parameter sets in sample entries or samples (handler: Volumetric visual media)",
+      "type" : "v3cg"
+    },
+    {
+      "name" : "V3C Atlas Track",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas track",
+      "type" : "v3cs"
+    },
+    {
+      "name" : "V3C Atlas Tile Track",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas tile track",
+      "type" : "v3ct"
+    },
+    {
+      "name" : "V3C Bitstream Track With Atlas Parameter Sets Only In Sample Entries",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C bitstream track with atlas parameter sets only in sample entries (handler: Volumetric visual media)",
+      "type" : "v3e1"
+    },
+    {
+      "name" : "V3C Bitstream Track With Atlas Parameter Sets In Sample Entries Or Samples",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C bitstream track with atlas parameter sets in sample entries or samples (handler: Volumetric visual media)",
+      "type" : "v3eg"
+    },
+    {
+      "name" : "Multi-track Encapsulation Mode For V3C Data With Partial Access Support",
+      "specification" : "V3C-SYS",
+      "summary" : "Multi-track encapsulation mode for V3C data with partial access support",
+      "type" : "v3mp"
+    },
+    {
+      "name" : "Multi-track Encapsulation Mode For V3C Data",
+      "specification" : "V3C-SYS",
+      "summary" : "Multi-track encapsulation mode for V3C data",
+      "type" : "v3mt"
+    },
+    {
+      "name" : "Non-timed Encpasulation Mode For V3C Data",
+      "specification" : "V3C-SYS",
+      "summary" : "Non-timed encpasulation mode for V3C data",
+      "type" : "v3nt"
+    },
+    {
+      "name" : "V3C Spatial Region Collection",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C spatial region collection",
+      "type" : "v3sc"
+    },
+    {
+      "name" : "Single-track Encapsulation Mode For V3C Data",
+      "specification" : "V3C-SYS",
+      "summary" : "Single-track encapsulation mode for V3C data",
+      "type" : "v3st"
+    },
+    {
+      "name" : "V3C Atlas Tile Track With Atlas Tile Data",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas tile track with atlas tile data (handler: Volumetric visual media)",
+      "type" : "v3t1"
+    },
+    {
+      "name" : "V3C Atlas Tile Configuration",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C Atlas Tile Configuration (handler: Volumetric visual media)",
+      "type" : "v3tC"
+    },
+    {
+      "name" : "V3C Atlas Tile Configuration",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas tile configuration",
+      "type" : "v3tp"
+    },
+    {
+      "name" : "V3C Attribute Video Track",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C attribute video track",
+      "type" : "v3va"
+    },
+    {
+      "name" : "V3C Geometry Video Track",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C geometry video track",
+      "type" : "v3vg"
+    },
+    {
+      "name" : "V3C Occupancy Video Track",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C occupancy video track",
+      "type" : "v3vo"
+    },
+    {
+      "name" : "8 Bit Per Component YUVA 4:4:4:4. Packed Cb Y Cr A",
+      "specification" : "Apple",
+      "summary" : "8 bit per component YUVA 4:4:4:4. Packed Cb Y Cr A",
+      "type" : "v408"
+    },
+    {
+      "name" : "10 Bit Per Component YUV 4:4:4. 3 10-bit Unsigned Components Are Packed Into A 32-bit Little-endian Word",
+      "specification" : "Apple",
+      "summary" : "10 bit per component YUV 4:4:4. 3 10-bit unsigned components are packed into a 32-bit little-endian word",
+      "type" : "v410"
+    },
+    {
+      "name" : "V3C Atlas Parameter Set Sample Group",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas parameter set sample group (category: sample group)",
+      "type" : "vaps"
+    },
+    {
+      "name" : "SMPTE VC-1",
+      "specification" : "SMPTE",
+      "summary" : "SMPTE VC-1 (handler: Video, objectType: 0xA3)",
+      "type" : "vc-1"
+    },
+    {
+      "name" : "Auxiliary Video Depth",
+      "specification" : "ISO",
+      "summary" : "Auxiliary video depth",
+      "type" : "vdep"
+    },
+    {
+      "name" : "Video Extended Usage",
+      "specification" : "Apple",
+      "summary" : "Video Extended Usage (handler: Video)",
+      "type" : "vexu"
+    },
+    {
+      "name" : "Video",
+      "specification" : "ISO",
+      "summary" : "Video (category: handler)",
+      "type" : "vide"
+    },
+    {
+      "name" : "Viewpoint Entity Grouping",
+      "specification" : "OMAF",
+      "summary" : "Viewpoint entity grouping",
+      "type" : "vipo"
+    },
+    {
+      "name" : "View Priority",
+      "specification" : "NALu Video",
+      "summary" : "View priority (category: sample group)",
+      "type" : "vipr"
+    },
+    {
+      "name" : "WebVTT Source Label",
+      "specification" : "ISO-Text",
+      "summary" : "WebVTT Source Label (handler: Text)",
+      "type" : "vlab"
+    },
+    {
+      "name" : "Video Media Header, Overall Information (video Track Only)",
+      "specification" : "ISO",
+      "summary" : "video media header, overall information (video track only)",
+      "type" : "vmhd"
+    },
+    {
+      "name" : "Volumetric Visual Media",
+      "specification" : "ISO",
+      "summary" : "Volumetric visual media (category: handler)",
+      "type" : "volv"
+    },
+    {
+      "name" : "VVC Operating Points Information",
+      "specification" : "NALu Video",
+      "summary" : "VVC operating points information (category: sample group)",
+      "type" : "vopi"
+    },
+    {
+      "name" : "VP8 Video",
+      "specification" : "VPxx",
+      "summary" : "VP8 video (handler: Video)",
+      "type" : "vp08"
+    },
+    {
+      "name" : "VP9 Video",
+      "specification" : "VPxx",
+      "summary" : "VP9 video (handler: Video, objectType: 0xB1)",
+      "type" : "vp09"
+    },
+    {
+      "name" : "Volumetric Media Bounding Box",
+      "specification" : "V3C-SYS",
+      "summary" : "Volumetric media bounding box",
+      "type" : "vpbb"
+    },
+    {
+      "name" : "VP9 Codec Configuration",
+      "specification" : "VPxx",
+      "summary" : "VP9 Codec Configuration (handler: Video)",
+      "type" : "vpcC"
+    },
+    {
+      "name" : "Auxiliary Video Parallax",
+      "specification" : "ISO",
+      "summary" : "Auxiliary video parallax",
+      "type" : "vplx"
+    },
+    {
+      "name" : "Reference To A Track That Contains A 'vopi' Sample Group For VVC Video",
+      "specification" : "NALu Video",
+      "summary" : "reference to a track that contains a 'vopi' sample group for VVC video",
+      "type" : "vref"
+    },
+    {
+      "name" : "Reference To A VVC Operating Point Entity Group",
+      "specification" : "NALu Video",
+      "summary" : "reference to a VVC operating point entity group",
+      "type" : "vreg"
+    },
+    {
+      "name" : "Viewing Space",
+      "specification" : "OMAF",
+      "summary" : "Viewing space (handler: Metadata)",
+      "type" : "vrsp"
+    },
+    {
+      "name" : "View Scalability Information",
+      "specification" : "NALu Video",
+      "summary" : "View scalability information (handler: Video)",
+      "type" : "vsib"
+    },
+    {
+      "name" : "Viewing Space",
+      "specification" : "OMAF",
+      "summary" : "Viewing space",
+      "type" : "vssn"
+    },
+    {
+      "name" : "V3C Atlas Tile Component Track Grouping",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C atlas tile component track grouping",
+      "type" : "vtcg"
+    },
+    {
+      "name" : "WebVTTConfigurationBox",
+      "specification" : "ISO-Text",
+      "summary" : "WebVTTConfigurationBox (handler: Text)",
+      "type" : "vttC"
+    },
+    {
+      "name" : "V3C Unit Header",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C unit header",
+      "type" : "vunt"
+    },
+    {
+      "name" : "V3C Unit Header",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C unit header",
+      "type" : "vutp"
+    },
+    {
+      "name" : "Versatile Video Coding With Parameter Sets Only In Sample Entries",
+      "specification" : "NALu Video",
+      "summary" : "Versatile Video Coding with parameter sets only in sample entries (handler: Video)",
+      "type" : "vvc1"
+    },
+    {
+      "name" : "VVC Video Configuration",
+      "specification" : "NALu Video",
+      "summary" : "VVC video configuration (handler: Video)",
+      "type" : "vvcC"
+    },
+    {
+      "name" : "Versatile Video Coding With Non-VCL (Video Coding Layer) NAL (Network Abstraction Layer) Units Only",
+      "specification" : "NALu Video",
+      "summary" : "Versatile Video Coding with non-VCL (Video Coding Layer) NAL (Network Abstraction Layer) units only (handler: Video)",
+      "type" : "vvcN"
+    },
+    {
+      "name" : "VVC Bitstream",
+      "specification" : "NALu Video",
+      "summary" : "VVC bitstream",
+      "type" : "vvcb"
+    },
+    {
+      "name" : "VVC-based Viewport-independent OMAF Video Profile",
+      "specification" : "OMAF",
+      "summary" : "VVC-based viewport-independent OMAF video profile",
+      "type" : "vvci"
+    },
+    {
+      "name" : "Volumetric Visual Media Header",
+      "specification" : "ISO",
+      "summary" : "volumetric visual media header",
+      "type" : "vvhd"
+    },
+    {
+      "name" : "Versatile Video Coding With Parameter Sets In Sample Entries Or Samples",
+      "specification" : "NALu Video",
+      "summary" : "Versatile Video Coding with parameter sets in sample entries or samples (handler: Video)",
+      "type" : "vvi1"
+    },
+    {
+      "name" : "VVC Coded Image Item",
+      "specification" : "HEIF",
+      "summary" : "VVC coded image item",
+      "type" : "vvic"
+    },
+    {
+      "name" : "VVC Coded Image Sequence",
+      "specification" : "HEIF",
+      "summary" : "VVC coded image sequence",
+      "type" : "vvis"
+    },
+    {
+      "name" : "VVC Network Abstraction Layer Unit Configuration",
+      "specification" : "NALu Video",
+      "summary" : "VVC Network Abstraction Layer unit configuration (handler: Video)",
+      "type" : "vvnC"
+    },
+    {
+      "name" : "OMAF VVC Image Profile",
+      "specification" : "OMAF",
+      "summary" : "OMAF VVC image profile",
+      "type" : "vvoi"
+    },
+    {
+      "name" : "Versatile Video Coding (VVC) Subpicture Track That Does Not Contain A Conforming VVC Bitstream",
+      "specification" : "NALu Video",
+      "summary" : "Versatile Video Coding (VVC) subpicture track that does not contain a conforming VVC bitstream (handler: Video)",
+      "type" : "vvs1"
+    },
+    {
+      "name" : "V3C Video Component Restricted Scheme",
+      "specification" : "V3C-SYS",
+      "summary" : "V3C video component restricted scheme (category: restricted video scheme)",
+      "type" : "vvvc"
+    },
+    {
+      "name" : "Multiview Scene Information",
+      "specification" : "NALu Video",
+      "summary" : "Multiview Scene Information",
+      "type" : "vwdi"
+    },
+    {
+      "name" : "View Identifier",
+      "specification" : "NALu Video",
+      "summary" : "View identifier (handler: Video)",
+      "type" : "vwid"
+    },
+    {
+      "name" : "Viewpoint Toolset Brand",
+      "specification" : "OMAF",
+      "summary" : "Viewpoint toolset brand",
+      "type" : "vwpt"
+    },
+    {
+      "name" : "Sub-track Can Be Scaled In Terms Of Number Of Views",
+      "specification" : "ISO",
+      "summary" : "Sub-track can be scaled in terms of number of views (category: track sel.)",
+      "type" : "vwsc"
+    },
+    {
+      "name" : "8 Bits YUV 422 Packed Cr Y0 Cb Y1",
+      "specification" : "UNCV",
+      "summary" : "8 bits YUV 422 packed Cr Y0 Cb Y1",
+      "type" : "vyuy"
+    },
+    {
+      "name" : "White Balance Bracketing",
+      "specification" : "HEIF",
+      "summary" : "White balance bracketing (category: sample group)",
+      "type" : "wbbr"
+    },
+    {
+      "name" : "Wipe Transition Effect",
+      "specification" : "HEIF",
+      "summary" : "Wipe transition effect",
+      "type" : "wipe"
+    },
+    {
+      "name" : "Segment Position In The Watermark Pattern",
+      "specification" : "DASH-IF watermarking",
+      "summary" : "segment position in the watermark pattern",
+      "type" : "wmpi"
+    },
+    {
+      "name" : "WebVTT Data",
+      "specification" : "ISO-Text",
+      "summary" : "WebVTT data (handler: Text)",
+      "type" : "wvtt"
+    },
+    {
+      "name" : "XML Container",
+      "specification" : "ISO",
+      "summary" : "XML container",
+      "type" : "xml "
+    },
+    {
+      "name" : "10 Bits YUV 422 Packed Little-Endian Y0 Cb Y1 Cr",
+      "specification" : "UNCV",
+      "summary" : "10 bits YUV 422 packed Little-Endian Y0 Cb Y1 Cr",
+      "type" : "y210"
+    },
+    {
+      "name" : "Year When Media Was Recorded",
+      "specification" : "3GPP",
+      "summary" : "Year when media was recorded",
+      "type" : "yrrc"
+    },
+    {
+      "name" : "Google Specification For Use By YouTube Apps",
+      "specification" : "Youtube",
+      "summary" : "Google specification for use by YouTube apps",
+      "type" : "yt4 "
+    },
+    {
+      "name" : "8 Bits YUV 411 Packed Y0 Y1 Cb Y2 Y3 Cr",
+      "specification" : "UNCV",
+      "summary" : "8 bits YUV 411 packed Y0 Y1 Cb Y2 Y3 Cr",
+      "type" : "yuv1"
+    },
+    {
+      "name" : "8 Bit Per Component YUV 4:2:2. Packed Y0 Cb Y1 Cr",
+      "specification" : "Apple",
+      "summary" : "8 bit per component YUV 4:2:2. Packed Y0 Cb Y1 Cr",
+      "type" : "yuv2"
+    },
+    {
+      "name" : "8 Bits YUV 422 Packed Y0 Cr Y1 Cb",
+      "specification" : "UNCV",
+      "summary" : "8 bits YUV 422 packed Y0 Cr Y1 Cb",
+      "type" : "yvyu"
+    },
+    {
+      "name" : "Zoom Transition Effect",
+      "specification" : "HEIF",
+      "summary" : "Zoom transition effect",
+      "type" : "zoom"
     }
-  ]
+  ],
+  "metadata" : {
+    "fetchedAt" : "2025-10-07T07:49:04.114Z",
+    "recordCount" : 1167,
+    "source" : "https:\/\/mp4ra.org\/api\/boxes"
+  }
 }

--- a/Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift
+++ b/Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift
@@ -8,4 +8,39 @@ final class ISOInspectorCLIScaffoldTests: XCTestCase {
         XCTAssertTrue(summary.contains(ISOInspectorKit.projectName))
         XCTAssertTrue(summary.contains("Phase A"))
     }
+
+    func testHelpTextMentionsMP4RARefreshCommand() {
+        let help = ISOInspectorCLIRunner.helpText()
+        XCTAssertTrue(help.contains("mp4ra"))
+        XCTAssertTrue(help.contains("refresh"))
+    }
+
+    func testRunExecutesMP4RARefreshWithParsedArguments() throws {
+        var capturedSource: URL?
+        var capturedOutput: URL?
+        let environment = ISOInspectorCLIEnvironment(
+            refreshCatalog: { source, output in
+                capturedSource = source
+                capturedOutput = output
+            },
+            print: { _ in },
+            printError: { _ in }
+        )
+
+        ISOInspectorCLIRunner.run(
+            arguments: [
+                "isoinspect",
+                "mp4ra",
+                "refresh",
+                "--source",
+                "https://example.com/custom.json",
+                "--output",
+                "/tmp/catalog.json"
+            ],
+            environment: environment
+        )
+
+        XCTAssertEqual(capturedSource, URL(string: "https://example.com/custom.json"))
+        XCTAssertEqual(capturedOutput?.path, "/tmp/catalog.json")
+    }
 }

--- a/Tests/ISOInspectorKitTests/BoxCatalogTests.swift
+++ b/Tests/ISOInspectorKitTests/BoxCatalogTests.swift
@@ -8,7 +8,7 @@ final class BoxCatalogTests: XCTestCase {
 
         let descriptor = catalog.descriptor(for: header)
 
-        XCTAssertEqual(descriptor?.name, "File Type Box")
+        XCTAssertEqual(descriptor?.name, "File Type And Compatibility")
         XCTAssertTrue(descriptor?.summary.contains("compatibility") ?? false)
     }
 

--- a/Tests/ISOInspectorKitTests/MP4RACatalogRefresherTests.swift
+++ b/Tests/ISOInspectorKitTests/MP4RACatalogRefresherTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class MP4RACatalogRefresherTests: XCTestCase {
+    private struct StubDataProvider: MP4RARegistryDataProvider {
+        let payload: Data
+        let sourceURL: URL
+
+        func fetchRegistryPayload() throws -> Data {
+            payload
+        }
+    }
+
+    func testBuildCatalogTransformsRecords() throws {
+        let payload = Data("""
+        [
+            {"code":"abcd","description":"example description","specification":"ISO"},
+            {"code":"aud$20","description":"Access unit delimiter","specification":"NALu Video","type":"sample group"},
+            {"code":"efgh","description":"audio handler entry","specification":"Example","handler":"Audio","ObjectType":"0xAF"},
+            {"code":"bad","description":"invalid length","specification":"Test"}
+        ]
+        """.utf8)
+        let provider = StubDataProvider(payload: payload, sourceURL: URL(string: "https://example.com/api")!)
+        let fixedDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let refresher = MP4RACatalogRefresher(dataProvider: provider, clock: { fixedDate })
+
+        let catalog = try refresher.makeCatalog()
+
+        XCTAssertEqual(catalog.metadata.source, "https://example.com/api")
+        XCTAssertEqual(catalog.metadata.recordCount, 3)
+        XCTAssertEqual(catalog.boxes.map(\.type), ["abcd", "aud ", "efgh"])
+        XCTAssertEqual(catalog.boxes[0].name, "Example Description")
+        XCTAssertEqual(catalog.boxes[0].summary, "example description")
+        XCTAssertEqual(catalog.boxes[0].specification, "ISO")
+        XCTAssertNil(catalog.boxes[0].version)
+        XCTAssertNil(catalog.boxes[0].flags)
+
+        XCTAssertEqual(catalog.boxes[1].type, "aud ")
+        XCTAssertEqual(catalog.boxes[1].name, "Access Unit Delimiter")
+        XCTAssertEqual(catalog.boxes[1].summary, "Access unit delimiter (category: sample group)")
+
+        XCTAssertEqual(catalog.boxes[2].summary, "audio handler entry (handler: Audio, objectType: 0xAF)")
+        XCTAssertEqual(catalog.boxes[2].name, "Audio Handler Entry")
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        XCTAssertEqual(catalog.metadata.fetchedAt, formatter.string(from: fixedDate))
+    }
+
+    func testMakeCatalogMergesBaselineEntries() throws {
+        let payload = Data("""
+        [
+            {"code":"ftyp","description":"file type and compatibility","specification":"ISO"},
+            {"code":"uuid","description":"user-extension box","specification":"ISO"}
+        ]
+        """.utf8)
+        let provider = StubDataProvider(payload: payload, sourceURL: URL(string: "https://example.com/api")!)
+        let refresher = MP4RACatalogRefresher(dataProvider: provider, clock: { Date(timeIntervalSince1970: 1_700_000_000) })
+
+        let baseline = MP4RACatalogRefresher.Catalog(
+            metadata: .init(source: "baseline", fetchedAt: "", recordCount: 1),
+            boxes: [
+                .init(
+                    type: "ftyp",
+                    uuid: nil,
+                    name: "File Type Box",
+                    summary: "Identifies the file type and compatibility brands for the bitstream.",
+                    specification: "ISO/IEC 14496-12",
+                    version: 0,
+                    flags: "000001"
+                ),
+                .init(
+                    type: "uuid",
+                    uuid: "11111111-1111-1111-1111-111111111111",
+                    name: "KLV Sample Entry",
+                    summary: "Carries SMPTE KLV sample metadata using a registered UUID container.",
+                    specification: "SMPTE ST 336",
+                    version: nil,
+                    flags: nil
+                )
+            ]
+        )
+
+        let catalog = try refresher.makeCatalog(baseline: baseline)
+
+        XCTAssertEqual(catalog.boxes.count, 2)
+        let ftyp = catalog.boxes.first { $0.type == "ftyp" }
+        let uuid = catalog.boxes.first { $0.type == "uuid" }
+
+        let ftypEntry = try XCTUnwrap(ftyp)
+        XCTAssertNil(ftypEntry.uuid)
+        XCTAssertEqual(ftypEntry.name, "File Type And Compatibility")
+        XCTAssertEqual(ftypEntry.summary, "Identifies the file type and compatibility brands for the bitstream.")
+        XCTAssertEqual(ftypEntry.specification, "ISO/IEC 14496-12")
+        XCTAssertEqual(ftypEntry.version, 0)
+        XCTAssertEqual(ftypEntry.flags, "000001")
+
+        let uuidEntry = try XCTUnwrap(uuid)
+        XCTAssertEqual(uuidEntry.uuid, "11111111-1111-1111-1111-111111111111")
+        XCTAssertEqual(uuidEntry.name, "KLV Sample Entry")
+        XCTAssertEqual(uuidEntry.summary, "Carries SMPTE KLV sample metadata using a registered UUID container.")
+        XCTAssertEqual(uuidEntry.specification, "SMPTE ST 336")
+    }
+
+    func testWriteCatalogPersistsJSONWithMetadata() throws {
+        struct Registry: Decodable {
+            struct Metadata: Decodable {
+                let source: String
+                let fetchedAt: String
+                let recordCount: Int
+            }
+
+            struct Entry: Decodable {
+                let type: String
+                let uuid: String?
+                let name: String
+                let summary: String
+                let specification: String?
+                let version: Int?
+                let flags: String?
+            }
+
+            let metadata: Metadata
+            let boxes: [Entry]
+        }
+
+        let payload = Data("""
+        [
+            {"code":"abcd","description":"example description","specification":"ISO"}
+        ]
+        """.utf8)
+        let provider = StubDataProvider(payload: payload, sourceURL: URL(string: "https://example.com/api")!)
+        let refresher = MP4RACatalogRefresher(dataProvider: provider, clock: { Date(timeIntervalSince1970: 1_700_000_000) })
+        let outputURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("json")
+
+        let catalog = try refresher.writeCatalog(to: outputURL)
+        let data = try Data(contentsOf: outputURL)
+        let decoded = try JSONDecoder().decode(Registry.self, from: data)
+
+        XCTAssertEqual(decoded.metadata.source, catalog.metadata.source)
+        XCTAssertEqual(decoded.metadata.recordCount, 1)
+        XCTAssertEqual(decoded.boxes.count, 1)
+        XCTAssertEqual(decoded.boxes[0].type, "abcd")
+        XCTAssertEqual(decoded.boxes[0].name, "Example Description")
+        XCTAssertEqual(decoded.boxes[0].summary, "example description")
+    }
+}

--- a/Tests/ISOInspectorKitTests/ParsePipelineLiveTests.swift
+++ b/Tests/ISOInspectorKitTests/ParsePipelineLiveTests.swift
@@ -76,7 +76,7 @@ final class ParsePipelineLiveTests: XCTestCase {
         }
         XCTAssertEqual(startEvents.count, 2)
 
-        XCTAssertEqual(startEvents[0].metadata?.name, "File Type Box")
+        XCTAssertEqual(startEvents[0].metadata?.name, "File Type And Compatibility")
         XCTAssertNil(startEvents[1].metadata)
     }
 

--- a/todo.md
+++ b/todo.md
@@ -1,4 +1,4 @@
 # TODO
 
 - [x] #1 Implement ParsePipeline.live() to iterate through MP4 boxes and emit streaming parse events.
-- [ ] #2 Automate refreshing MP4RABoxes.json from the upstream registry and document the update workflow.
+- [x] #2 Automate refreshing MP4RABoxes.json from the upstream registry and document the update workflow.


### PR DESCRIPTION
## Summary
- update the MP4RA refresher to reuse legacy catalog entries and metadata when the live registry lacks details
- add coverage for the merge behaviour and align existing tests with the new MP4RA naming
- regenerate MP4RABoxes.json with merged legacy details and refreshed provenance metadata

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e433ab422c83219dbc4a4534609199