### PR TITLE
Fix MP4RA validator catalog path handling

### DIFF
--- a/.github/workflows/validate-mp4ra-minimal.yml
+++ b/.github/workflows/validate-mp4ra-minimal.yml
@@ -1,0 +1,23 @@
+name: Validate MP4RA Catalog (Minimal)
+
+on:
+  pull_request:
+    paths:
+      - 'Sources/ISOInspectorKit/Resources/MP4RABoxes.json'
+      - 'scripts/validate_mp4ra_minimal.py'
+  push:
+    branches: [ main ]
+    paths:
+      - 'Sources/ISOInspectorKit/Resources/MP4RABoxes.json'
+      - 'scripts/validate_mp4ra_minimal.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run minimal validator
+        run: python scripts/validate_mp4ra_minimal.py

--- a/README.md
+++ b/README.md
@@ -21,5 +21,20 @@ Monorepo for the ISOInspector suite: a Swift-based ISO Base Media File Format (M
    swift test
    ```
 
+## MP4RA Catalog Maintenance
+The repository maintains a pinned snapshot of the MP4 Registration Authority box catalog in `Sources/ISOInspectorKit/Resources/MP4RABoxes.json`.
+To update the snapshot and keep CI green:
+
+1. Download the latest catalog JSON from the MP4RA source and overwrite `Sources/ISOInspectorKit/Resources/MP4RABoxes.json`.
+2. Run the minimal validator locally before committing:
+   ```sh
+   python scripts/validate_mp4ra_minimal.py Sources/ISOInspectorKit/Resources/MP4RABoxes.json
+   ```
+   The script also defaults to this path when invoked without arguments.
+   A `Validation OK` message indicates the file matches the required structure and formatting (two-space indentation, LF
+   newlines, valid identifiers, etc.).
+3. Commit the refreshed snapshot together with any fixes required by the validator. The GitHub Actions workflow
+   (`validate-mp4ra-minimal.yml`) executes the same script on pull requests and pushes to `main` to enforce consistency.
+
 ## Next Steps
 Consult `DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md` for feature-level deliverables and `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md` for task sequencing. Begin by enhancing the IO foundations described in Phase A.

--- a/scripts/validate_mp4ra_minimal.py
+++ b/scripts/validate_mp4ra_minimal.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Minimal validator for MP4RABoxes.json."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import List
+
+DEFAULT_CATALOG_PATH = Path("Sources/ISOInspectorKit/Resources/MP4RABoxes.json")
+
+FOURCC_RE = re.compile(r"^[\x20-\x7E]{4}$")
+UUID_DASHED_RE = re.compile(
+    r"^[0-9a-fA-F]{8}(?:-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$"
+)
+BOM_UTF8 = b"\xef\xbb\xbf"
+
+
+def validate_utf8(path: Path, errors: List[str]) -> str | None:
+    if not path.exists():
+        errors.append(f"File not found: {path}")
+        return None
+
+    raw = path.read_bytes()
+    if raw.startswith(BOM_UTF8):
+        errors.append("File must not contain a UTF-8 BOM")
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        errors.append(f"File is not valid UTF-8: {exc}")
+        return None
+
+    if "\r" in text:
+        errors.append("File must use LF (\n) line endings")
+
+    if "\t" in text:
+        errors.append("File must not contain tab characters; use two-space indentation")
+
+    for idx, line in enumerate(text.splitlines(), start=1):
+        stripped = line.lstrip(" ")
+        indent_len = len(line) - len(stripped)
+        if indent_len and indent_len % 2 != 0:
+            errors.append(
+                f"Line {idx}: indentation must be in multiples of two spaces (found {indent_len})"
+            )
+    return text
+
+
+def validate_structure(data: object, errors: List[str]) -> None:
+    if not isinstance(data, dict):
+        errors.append("Top-level JSON structure must be an object")
+        return
+
+    provenance = data.get("provenance")
+    if provenance is not None:
+        if not isinstance(provenance, dict):
+            errors.append("provenance must be an object if present")
+        else:
+            fetched_at = provenance.get("fetchedAt")
+            if fetched_at is not None and (
+                not isinstance(fetched_at, str) or not fetched_at.strip()
+            ):
+                errors.append("provenance.fetchedAt must be a non-empty string when provided")
+
+            sources = provenance.get("sources")
+            if sources is not None:
+                if not isinstance(sources, list) or not sources or not all(
+                    isinstance(item, str) and item.strip() for item in sources
+                ):
+                    errors.append(
+                        "provenance.sources must be a non-empty array of strings when provided"
+                    )
+
+    boxes = data.get("boxes")
+    if not isinstance(boxes, list):
+        errors.append("boxes must be an array of box entries")
+        return
+
+    seen_identifiers: set[str] = set()
+
+    for index, entry in enumerate(boxes):
+        context = f"[index: {index}]"
+        if not isinstance(entry, dict):
+            errors.append(f"{context} Box entry must be an object")
+            continue
+
+        identifier = entry.get("type")
+        if not isinstance(identifier, str) or not identifier:
+            errors.append(f"{context} type must be a non-empty string")
+            continue
+
+        if identifier in seen_identifiers:
+            errors.append(f"Duplicate type identifier detected: {identifier}")
+            continue
+        seen_identifiers.add(identifier)
+
+        if len(identifier) == 4 and FOURCC_RE.match(identifier):
+            pass
+        elif identifier == "uuid":
+            uuid_value = entry.get("uuid")
+            if not isinstance(uuid_value, str) or not UUID_DASHED_RE.match(uuid_value):
+                errors.append(
+                    f"{context} uuid entries must include a UUID field in dashed hexadecimal form"
+                )
+        else:
+            errors.append(
+                f"{context} type must be a FourCC (4 printable ASCII characters) or the literal 'uuid'"
+            )
+
+        for field in ("name", "summary", "specification"):
+            if field in entry:
+                value = entry[field]
+                if not isinstance(value, str) or not value.strip():
+                    errors.append(f"{context} {field} must be a non-empty string when present")
+
+        if "flags" in entry and not isinstance(entry["flags"], str):
+            errors.append(f"{context} flags must be stored as a string")
+
+        if "version" in entry and not isinstance(entry["version"], int):
+            errors.append(f"{context} version must be an integer")
+
+
+
+def load_json(text: str, errors: List[str]) -> object | None:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        errors.append(f"JSON parse error: {exc}")
+        return None
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) == 1:
+        path = DEFAULT_CATALOG_PATH
+    elif len(argv) == 2:
+        path = Path(argv[1])
+    else:
+        print("Usage: validate_mp4ra_minimal.py [path-to-MP4RABoxes.json]", file=sys.stderr)
+        return 2
+
+    errors: List[str] = []
+
+    text = validate_utf8(path, errors)
+    data = load_json(text, errors) if text is not None else None
+
+    if data is not None:
+        validate_structure(data, errors)
+
+    if errors:
+        print("Validation FAILED:")
+        for err in errors:
+            print(f" - {err}")
+        return 1
+
+    print("Validation OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow and README instructions to point at the catalog under Sources/ISOInspectorKit/Resources
- enhance the validator to default to the catalog path and validate the array-based MP4RA entry format used by the repository

## Testing
- python scripts/validate_mp4ra_minimal.py

------
https://chatgpt.com/codex/tasks/task_e_68e4cbec03808321ab9785a40434e0a4