### PR TITLE
Add metadata-driven validation and CLI reporting formatter

### DIFF
--- a/DOCS/INPROGRESS/08_Metadata_Driven_Validation_and_Reporting.md
+++ b/DOCS/INPROGRESS/08_Metadata_Driven_Validation_and_Reporting.md
@@ -7,33 +7,49 @@ Deliver validation and reporting enhancements that use the MP4RA-backed metadata
 ## 🧩 Context
 
 - Task B4 integrated the MP4RA catalog into the streaming pipeline, enabling each parse event to carry descriptive
+
   metadata for known boxes and logging unknown types for research
   follow-up.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/Summary_of_Work.md†L5-L16】
+
 - The technical specification defines validation rule VR-003, which compares version and flag fields against MP4RA data,
+
   and outlines how the event stream feeds validation chains and CLI/UI reporting
-  layers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L63】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L64-L83】
+
+layers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L63】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L64-L83】
+
 - Execution workplan phase B prioritizes metadata-aware validation immediately after the streaming pipeline, ensuring
+
   downstream features inherit the enriched catalog context without
   delay.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L30】
 
 ## ✅ Success Criteria
 
 - Validation layer inspects MP4RA metadata (e.g., expected version/flags) and raises rule VR-003 warnings when stream
+
   events diverge from catalog definitions.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L52-L67】
+
 - CLI and future UI reporters display box names, descriptions, and validation outcomes sourced from the catalog for each
+
   emitted event.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L33-L63】
+
 - Unknown or stale MP4RA entries are surfaced as research issues with enough context to update the catalog refresh
+
   workflow documented in task R1.【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/Summary_of_Work.md†L9-L26】
 
 ## 🔧 Implementation Notes
 
 - Extend validation pipeline to attach MP4RA-derived descriptors to `ParseEvent` results and implement rule handlers that compare event payloads against catalog expectations before raising issues.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L67】
 - Update CLI reporting utilities to render descriptive names and validation summaries; capture follow-up requirements
+
   for SwiftUI consumers while maintaining streaming performance
-  guarantees.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L63】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L30】
+
+guarantees.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L1-L63】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L30】
+
 - Coordinate with archived B4 notes for catalog structure and refresh automation guidance when designing fallback
+
   logging and stale entry detection
-  logic.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L1-L36】【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/07_R1_MP4RA_Catalog_Refresh.md†L5-L44】
+
+logic.【F:DOCS/TASK_ARCHIVE/06_B4_MP4RA_Metadata_Integration/B4_MP4RA_Metadata_Integration.md†L1-L36】【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/07_R1_MP4RA_Catalog_Refresh.md†L5-L44】
 
 ## 🧠 Source References
 

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,17 @@
+# Summary of Work — Metadata Validation and Reporting
+
+## Completed Tasks
+
+- Added validation models and integrated `BoxValidator` into `ParsePipeline.live()` so stream events surface MP4RA-driven warnings when version/flags diverge and unknown boxes appear.
+- Introduced a reusable CLI `EventConsoleFormatter` that prints catalog names, summaries, and validation outcomes for each `ParseEvent` to prepare downstream `inspect` tooling.
+- Captured follow-up puzzle `@todo #3` for implementing the remaining validation rules and documented CLI wiring needs in `DOCS/INPROGRESS/next_tasks.md`.
+
+## Testing
+
+- `swift test`
+
+## Notes
+
+- Unknown box encounters now raise VR-006 research issues while continuing to log through `DiagnosticsLogger` for catalog refresh workflows.
+- CLI output leverages the shared box identifier string helper so both SwiftUI and CLI layers can display consistent
+  identifiers.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,4 +1,7 @@
 # Next Tasks
 
 - [ ] Outline the additional downstream parser follow-ups now unlocked by real-time streaming events (e.g., catalog
+
   integration test coverage and fallback handling).
+
+- [ ] Wire the console formatter into an `inspect` command so validation summaries appear in the CLI pipeline.

--- a/Sources/ISOInspectorCLI/EventConsoleFormatter.swift
+++ b/Sources/ISOInspectorCLI/EventConsoleFormatter.swift
@@ -1,0 +1,46 @@
+import Foundation
+import ISOInspectorKit
+
+public struct EventConsoleFormatter {
+    public init() {}
+
+    public func format(_ event: ParseEvent) -> String {
+        var segments: [String] = []
+        segments.append(prefix(for: event))
+        segments.append(describe(event))
+
+        if let metadata = event.metadata {
+            segments.append("— \(metadata.summary)")
+        }
+
+        if !event.validationIssues.isEmpty {
+            let issues = event.validationIssues.map(issueDescription).joined(separator: "; ")
+            segments.append("[\(issues)]")
+        }
+
+        return segments.joined(separator: " ")
+    }
+
+    private func prefix(for event: ParseEvent) -> String {
+        switch event.kind {
+        case let .willStartBox(header, depth):
+            return "[offset \(event.offset)] ▶︎ depth \(depth) \(header.identifierString)"
+        case let .didFinishBox(header, depth):
+            return "[offset \(event.offset)] ◀︎ depth \(depth) \(header.identifierString)"
+        }
+    }
+
+    private func describe(_ event: ParseEvent) -> String {
+        if let metadata = event.metadata {
+            return "\(metadata.name)"
+        }
+        switch event.kind {
+        case let .willStartBox(header, _), let .didFinishBox(header, _):
+            return "Box \(header.identifierString)"
+        }
+    }
+
+    private func issueDescription(_ issue: ValidationIssue) -> String {
+        "\(issue.ruleID) \(issue.severity.rawValue): \(issue.message)"
+    }
+}

--- a/Sources/ISOInspectorKit/ISO/BoxHeader+Identifier.swift
+++ b/Sources/ISOInspectorKit/ISO/BoxHeader+Identifier.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension BoxHeader {
+    public var identifierString: String {
+        if let uuid {
+            return "uuid::\(uuid.uuidString.lowercased())"
+        }
+        return type.rawValue
+    }
+}

--- a/Sources/ISOInspectorKit/Validation/BoxValidator.swift
+++ b/Sources/ISOInspectorKit/Validation/BoxValidator.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+protocol BoxValidationRule: Sendable {
+    func issues(for event: ParseEvent, reader: RandomAccessReader) -> [ValidationIssue]
+}
+
+struct BoxValidator: Sendable {
+    private let rules: [any BoxValidationRule]
+
+    init(rules: [any BoxValidationRule] = [VersionFlagsRule(), UnknownBoxRule()]) {
+        self.rules = rules
+    }
+
+    func annotate(event: ParseEvent, reader: RandomAccessReader) -> ParseEvent {
+        let issues = rules.flatMap { $0.issues(for: event, reader: reader) }
+        guard !issues.isEmpty else {
+            return event
+        }
+        return ParseEvent(
+            kind: event.kind,
+            offset: event.offset,
+            metadata: event.metadata,
+            validationIssues: issues
+        )
+    }
+}
+
+private struct VersionFlagsRule: BoxValidationRule {
+    func issues(for event: ParseEvent, reader: RandomAccessReader) -> [ValidationIssue] {
+        guard case let .willStartBox(header, _) = event.kind else { return [] }
+        guard let descriptor = event.metadata else { return [] }
+        guard descriptor.version != nil || descriptor.flags != nil else { return [] }
+
+        let payloadRange = header.payloadRange
+        guard payloadRange.count >= 4 else {
+            return [ValidationIssue(
+                ruleID: "VR-003",
+                message: "\(header.identifierString) payload too small for version/flags check (expected 4 bytes, found \(payloadRange.count)).",
+                severity: .warning
+            )]
+        }
+
+        do {
+            let data = try reader.read(at: payloadRange.lowerBound, count: 4)
+            guard data.count == 4 else {
+                return [ValidationIssue(
+                    ruleID: "VR-003",
+                    message: "\(header.identifierString) payload truncated during version/flags check (expected 4 bytes, found \(data.count)).",
+                    severity: .warning
+                )]
+            }
+
+            let actualVersion = Int(data[0])
+            let actualFlags = data[1...3].reduce(UInt32(0)) { partial, byte in
+                (partial << 8) | UInt32(byte)
+            }
+
+            var issues: [ValidationIssue] = []
+            if let expectedVersion = descriptor.version, expectedVersion != actualVersion {
+                issues.append(ValidationIssue(
+                    ruleID: "VR-003",
+                    message: "\(header.identifierString) version mismatch: expected \(expectedVersion) but found \(actualVersion).",
+                    severity: .warning
+                ))
+            }
+            if let expectedFlags = descriptor.flags, expectedFlags != actualFlags {
+                issues.append(ValidationIssue(
+                    ruleID: "VR-003",
+                    message: "\(header.identifierString) flags mismatch: expected 0x\(expectedFlags.paddedHex(length: 6)) but found 0x\(actualFlags.paddedHex(length: 6))",
+                    severity: .warning
+                ))
+            }
+            return issues
+        } catch {
+            return [ValidationIssue(
+                ruleID: "VR-003",
+                message: "\(header.identifierString) failed to read version/flags: \(error)",
+                severity: .warning
+            )]
+        }
+    }
+}
+
+private struct UnknownBoxRule: BoxValidationRule {
+    func issues(for event: ParseEvent, reader: RandomAccessReader) -> [ValidationIssue] {
+        guard case let .willStartBox(header, _) = event.kind else { return [] }
+        guard event.metadata == nil else { return [] }
+        return [ValidationIssue(
+            ruleID: "VR-006",
+            message: "Unknown box type \(header.identifierString) encountered; schedule catalog research.",
+            severity: .info
+        )]
+    }
+}
+
+// @todo #3 Implement remaining validation rules (VR-001, VR-002, VR-004, VR-005) using streaming context and metadata stack.
+
+private extension Range where Bound == Int64 {
+    var count: Int { Int(upperBound - lowerBound) }
+}
+
+private extension UInt32 {
+    func paddedHex(length: Int) -> String {
+        let value = String(self, radix: 16, uppercase: true)
+        guard value.count < length else { return value }
+        return String(repeating: "0", count: length - value.count) + value
+    }
+}

--- a/Sources/ISOInspectorKit/Validation/ValidationIssue.swift
+++ b/Sources/ISOInspectorKit/Validation/ValidationIssue.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct ValidationIssue: Equatable, Sendable {
+    public enum Severity: String, Equatable, Sendable {
+        case info
+        case warning
+        case error
+    }
+
+    public let ruleID: String
+    public let message: String
+    public let severity: Severity
+
+    public init(ruleID: String, message: String, severity: Severity) {
+        self.ruleID = ruleID
+        self.message = message
+        self.severity = severity
+    }
+}

--- a/Tests/ISOInspectorCLITests/EventConsoleFormatterTests.swift
+++ b/Tests/ISOInspectorCLITests/EventConsoleFormatterTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import ISOInspectorCLI
+@testable import ISOInspectorKit
+
+final class EventConsoleFormatterTests: XCTestCase {
+    func testFormatterIncludesMetadataDetails() throws {
+        let header = try makeHeader(type: "ftyp", size: 24)
+        let descriptor = try XCTUnwrap(BoxCatalog.shared.descriptor(for: header))
+        let event = ParseEvent(
+            kind: .willStartBox(header: header, depth: 0),
+            offset: 0,
+            metadata: descriptor
+        )
+
+        let formatter = EventConsoleFormatter()
+        let output = formatter.format(event)
+
+        XCTAssertTrue(output.contains(descriptor.name))
+        XCTAssertTrue(output.contains(descriptor.summary))
+    }
+
+    func testFormatterIncludesValidationIssues() throws {
+        let header = try makeHeader(type: "tkhd", size: 40)
+        let descriptor = BoxCatalog.shared.descriptor(for: header)
+        let issue = ValidationIssue(
+            ruleID: "VR-003",
+            message: "Expected version 0 but found 1",
+            severity: .warning
+        )
+        let event = ParseEvent(
+            kind: .willStartBox(header: header, depth: 1),
+            offset: 8,
+            metadata: descriptor,
+            validationIssues: [issue]
+        )
+
+        let formatter = EventConsoleFormatter()
+        let output = formatter.format(event)
+
+        XCTAssertTrue(output.contains("VR-003"))
+        XCTAssertTrue(output.contains("warning"))
+        XCTAssertTrue(output.contains("Expected version 0 but found 1"))
+    }
+
+    private func makeHeader(type: String, size: Int64) throws -> BoxHeader {
+        let fourCC = try FourCharCode(type)
+        let range = Int64(0)..<size
+        let payloadRange = Int64(8)..<size
+        return BoxHeader(
+            type: fourCC,
+            totalSize: size,
+            headerSize: 8,
+            payloadRange: payloadRange,
+            range: range,
+            uuid: nil
+        )
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -2,3 +2,4 @@
 
 - [x] #1 Implement ParsePipeline.live() to iterate through MP4 boxes and emit streaming parse events.
 - [x] #2 Automate refreshing MP4RABoxes.json from the upstream registry and document the update workflow.
+- [ ] #3 Implement remaining validation rules (VR-001, VR-002, VR-004, VR-005) using streaming context and metadata stack.


### PR DESCRIPTION
## Summary
- add validation issue models and integrate BoxValidator into the live parse pipeline so events emit VR-003 mismatches and VR-006 research issues
- expose a shared box identifier helper and create a CLI EventConsoleFormatter to print metadata summaries and validation results
- document the completed work and follow-up tasks in the in-progress summary and next task tracker

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e4e118df5c8321b1b6fe08c2e13105