### PR TITLE
Fix inspect command error handling concurrency

### DIFF
--- a/DOCS/INPROGRESS/09_B4_Metadata_Follow_Up_Planning.md
+++ b/DOCS/INPROGRESS/09_B4_Metadata_Follow_Up_Planning.md
@@ -9,11 +9,11 @@ consumers gain full metadata-aware coverage and fallbacks.
 
 - Task B4 in the execution workplan prioritizes integrating the MP4RA metadata catalog once streaming parse events are
   in place, and highlights the need for graceful handling of unknown
-  boxes.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L18-L30】
-- The technical specification describes how `ParsePipeline` should consult `BoxCatalog` to enrich events and enable validation/reporting layers to surface descriptive metadata.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L12-L40】
+  boxes.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L20】
+- The technical specification describes how `ParsePipeline` should consult `BoxCatalog` to enrich events and enable validation/reporting layers to surface descriptive metadata.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L12-L33】
 - The PRD backlog calls for metadata-driven validation and reporting so CLI/UI surfaces human-readable context and
   captures mismatches against MP4RA
-  definitions.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L41-L73】【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L70-L108】
+  definitions.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L59-L67】【F:DOCS/AI/ISOInspector_PRD_TODO.md†L61-L85】
 
 ## ✅ Success Criteria
 
@@ -32,7 +32,7 @@ consumers gain full metadata-aware coverage and fallbacks.
   success criteria.
 - Call out tooling or data needs (e.g., fixture MP4 files with custom UUID boxes) and whether new scripts must be added to `scripts/`.
 - Ensure proposed follow-ups map cleanly to workplan phases (e.g., B4 extensions before B5 validation or D2 CLI wiring)
-  to maintain dependency order.
+  to maintain dependency order.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L12-L36】
 
 ## 🧠 Source References
 
@@ -41,3 +41,44 @@ consumers gain full metadata-aware coverage and fallbacks.
 - [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
 - [`DOCS/RULES`](../RULES)
 - [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)
+
+## 📋 Prioritized Follow-Up Backlog
+
+| Priority | Task | Dependencies | Expected Artifacts |
+|----------|------|--------------|--------------------|
+| 1 | Extend `StreamingBoxWalker` integration tests to assert catalog lookups for standard and UUID boxes, including logging expectations for unknown identifiers.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L27-L33】 | `ParsePipeline.live()` fixture harness; bundled MP4RA catalog. | New integration test covering `ParsePipeline.live()` event metadata; log snapshot or assertion utilities verifying single logging per unknown type. |
+| 2 | Implement VR-003 metadata comparison rule to enforce MP4RA-defined version and flag constraints, emitting warnings when payload headers diverge.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L59-L65】 | VR-003 spec; metadata-enriched events from Task 1. | Unit and integration tests in `BoxValidatorTests` validating mismatched version/flags; documentation updates describing VR-003 behavior. |
+| 3 | Capture VR-006 research entries by persisting unknown box types with offsets into a research log, ensuring deduplication across runs.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L64-L67】【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/Summary_of_Work.md†L9-L17】 | Task 1 logging utilities; research backlog process from R1. | New persistence helper and test ensuring unknown boxes append to research log; CLI flag docs for enabling/disabling logging. |
+| 4 | Wire catalog metadata into CLI `inspect` streaming output with graceful fallback when descriptors are missing.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L23-L33】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L32-L36】 | EventConsoleFormatter; CLI pipeline skeleton. | Updated console formatter tests showing name/summary usage and placeholder text for unknown descriptors; CLI acceptance test capturing sample output. |
+| 5 | Provide metadata-aware adapters for future UI tree/detail panes, including placeholder descriptors when catalog entries are absent.【F:DOCS/AI/ISOInspector_PRD_TODO.md†L67-L113】 | Combine stores planned in Phase C; metadata-enriched events. | Interface contract document plus view model unit tests verifying fallback descriptors. |
+| 6 | Introduce regression fixtures that mix known, UUID, and custom boxes to cover fallback behaviors and ensure catalog refresh automation stays effective.【F:DOCS/AI/ISOInspector_PRD_TODO.md†L83-L85】【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/Summary_of_Work.md†L9-L26】 | Task 1 harness; scripts for fixture generation. | New media samples under `Tests/media/` with README describing provenance; automation script updates in `scripts/`. |
+
+## 🧪 Fixture & Scenario Coverage
+
+- **Standard boxes (`ftyp`, `moov`, `trak`)** — reuse existing small MP4 fixture to validate metadata names and VR-003 version checks once rule implementation lands.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L59-L65】
+- **UUID boxes** — craft targeted fixture with at least one cataloged UUID entry and one custom GUID to validate
+  descriptor lookups and fallback logging; store generation instructions alongside
+  fixture.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L27-L33】
+- **Unknown fourcc** — extend fuzz or synthetic fixture generation to insert unsupported types, confirming VR-006
+  logging and CLI fallback strings remain readable.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L64-L67】
+- **Malformed metadata** — create fixture toggles (e.g., incorrect version bits) to drive VR-003 warnings without
+  breaking structural parsing, ensuring validator surfaces actionable
+  messages.【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L59-L65】
+
+## 🧰 Consumer Integration & Acceptance Signals
+
+- **Validation pipeline** — `BoxValidator` should annotate events with VR-003 warnings when catalog expectations fail and continue emitting VR-006 info-level issues for unknown types; success is measured by `swift test` suites covering both rules and consistent attachment to `ParseEvent.validationIssues`.【F:Sources/ISOInspectorKit/ISO/ParsePipeline.swift†L32-L84】【F:DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md†L59-L67】
+- **CLI reporting** — `EventConsoleFormatter` and the upcoming `inspect` command must display catalog names/summaries when available, falling back to raw fourcc/UUID when metadata is missing; acceptance tests should snapshot CLI output for mixed-known/unknown fixtures.【F:Tests/ISOInspectorCLITests/EventConsoleFormatterTests.swift†L1-L42】【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L32-L36】
+- **Exporters/UI** — document expected adapters that map descriptors into JSON export metadata and UI view models, ensuring placeholders (`"Unknown box (uuid ...)"`) appear when descriptors are absent so downstream consumers do not crash.【F:DOCS/AI/ISOInspector_PRD_TODO.md†L67-L113】
+
+## ⚠️ Risks & Research Items
+
+- **Catalog drift** — Upstream MP4RA updates could invalidate cached descriptors; ensure automation from Task R1 remains
+  part of regression pipeline and schedule periodic refresh
+  checks.【F:DOCS/TASK_ARCHIVE/07_R1_MP4RA_Catalog_Refresh/Summary_of_Work.md†L9-L26】
+- **Fixture licensing** — Custom UUID samples may require generating synthetic media; confirm redistribution rights
+  before checking fixtures into the repository.
+- **Performance impact** — Additional logging and validation must avoid regressing streaming throughput; monitor parse
+  benchmarks once VR-003 and research logging are enabled.
+- **Unknown descriptor UX** — Need guidance from product/design on how unknown boxes should appear in UI/CLI to avoid
+  confusing operators; capture open question in design backlog.

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,26 @@
+# Summary of Work — Start Task Session
+
+## Completed Tasks
+
+- Captured the catalog-driven parser and consumer follow-up plan, outlining prioritized backlog items, fixture coverage,
+  and risk
+
+  notes for metadata integration.【F:DOCS/INPROGRESS/09_B4_Metadata_Follow_Up_Planning.md†L33-L87】
+
+- Updated the in-progress checklist to record completion of the metadata follow-up planning
+  task.【F:DOCS/INPROGRESS/next_tasks.md†L1-L7】
+- Wired the `isoinspect inspect` command so parse events stream through `EventConsoleFormatter`, printing catalog summaries and
+
+  validation issues while expanding CLI
+coverage.【F:Sources/ISOInspectorCLI/CLI.swift†L1-L136】【F:Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift†L1-L122】
+
+## Artifacts & References
+
+- Planning document: `DOCS/INPROGRESS/09_B4_Metadata_Follow_Up_Planning.md` (see sections on backlog and consumer integration).
+- Source materials: `DOCS/AI/ISOInspector_Execution_Guide/03_Technical_Spec.md`, `DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md`, and `DOCS/AI/ISOInspector_PRD_TODO.md` for traceability.
+- CLI implementation: `Sources/ISOInspectorCLI/CLI.swift` and tests in `Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift` demonstrate the new streaming output behavior.
+
+## Pending Follow-Ups
+
+- Execute VR-006 research logging along with CLI/UI metadata consumption once implementation tasks begin.
+- Implement VR-003 metadata comparison rule to satisfy the next tracked in-progress item and enrich CLI output.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,7 +1,8 @@
 # Next Tasks
 
-- [ ] Outline the additional downstream parser follow-ups now unlocked by real-time streaming events (e.g., catalog
+- [x] Outline the additional downstream parser follow-ups now unlocked by real-time streaming events (e.g., catalog
 
-  integration test coverage and fallback handling).
+  integration test coverage and fallback handling) in `09_B4_Metadata_Follow_Up_Planning.md`.
 
-- [ ] Wire the console formatter into an `inspect` command so validation summaries appear in the CLI pipeline.
+- [x] Wire the console formatter into an `inspect` command so validation summaries appear in the CLI pipeline.
+- [ ] Implement VR-003 metadata comparison rule so CLI and validation pipelines emit catalog-driven warnings.

--- a/Sources/ISOInspectorCLI/CLI.swift
+++ b/Sources/ISOInspectorCLI/CLI.swift
@@ -1,17 +1,29 @@
+import Dispatch
 import Foundation
 import ISOInspectorKit
 
 public struct ISOInspectorCLIEnvironment {
     public var refreshCatalog: (_ source: URL, _ output: URL) throws -> Void
+    public var makeReader: (_ url: URL) throws -> RandomAccessReader
+    public var parsePipeline: ParsePipeline
+    public var formatter: EventConsoleFormatter
     public var print: (String) -> Void
     public var printError: (String) -> Void
 
     public init(
         refreshCatalog: @escaping (_ source: URL, _ output: URL) throws -> Void,
+        makeReader: @escaping (_ url: URL) throws -> RandomAccessReader = { url in
+            try ChunkedFileReader(fileURL: url)
+        },
+        parsePipeline: ParsePipeline = .live(),
+        formatter: EventConsoleFormatter = EventConsoleFormatter(),
         print: @escaping (String) -> Void = { Swift.print($0) },
         printError: @escaping (String) -> Void = { message in fputs(message + "\n", stderr) }
     ) {
         self.refreshCatalog = refreshCatalog
+        self.makeReader = makeReader
+        self.parsePipeline = parsePipeline
+        self.formatter = formatter
         self.print = print
         self.printError = printError
     }
@@ -43,6 +55,8 @@ public enum ISOInspectorCLIRunner {
         switch first {
         case "mp4ra":
             handleMP4RACommand(Array(args.dropFirst()), environment: environment)
+        case "inspect":
+            handleInspectCommand(Array(args.dropFirst()), environment: environment)
         default:
             ISOInspectorCLIIO.printWelcome()
         }
@@ -51,6 +65,7 @@ public enum ISOInspectorCLIRunner {
     public static func helpText() -> String {
         "isoinspect — ISO BMFF (MP4/QuickTime) inspector CLI\n" +
             "  --help, -h    Show this help message.\n" +
+            "  inspect <file> Stream parse events with metadata and validation summaries.\n" +
             "  mp4ra refresh [--output <path>] [--source <url>]\n" +
             "                Refresh the bundled MP4RABoxes.json using the latest registry export."
     }
@@ -101,6 +116,40 @@ public enum ISOInspectorCLIRunner {
             case .unknownOption(let option):
                 return "Unknown option for mp4ra refresh: \(option)"
             }
+        }
+    }
+
+    private static func handleInspectCommand(
+        _ arguments: [String],
+        environment: ISOInspectorCLIEnvironment
+    ) {
+        guard let path = arguments.first else {
+            environment.printError("inspect requires a file path.")
+            return
+        }
+
+        let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let fileURL = URL(fileURLWithPath: path, relativeTo: cwd).standardizedFileURL
+
+        do {
+            let reader = try environment.makeReader(fileURL)
+            let events = environment.parsePipeline.events(for: reader)
+            let semaphore = DispatchSemaphore(value: 0)
+
+            Task {
+                do {
+                    for try await event in events {
+                        environment.print(environment.formatter.format(event))
+                    }
+                } catch {
+                    environment.printError("Failed to inspect file: \(error)")
+                }
+                semaphore.signal()
+            }
+
+            semaphore.wait()
+        } catch {
+            environment.printError("Failed to inspect file: \(error)")
         }
     }
 

--- a/Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift
+++ b/Tests/ISOInspectorCLITests/ISOInspectorCLIScaffoldTests.swift
@@ -15,6 +15,11 @@ final class ISOInspectorCLIScaffoldTests: XCTestCase {
         XCTAssertTrue(help.contains("refresh"))
     }
 
+    func testHelpTextMentionsInspectCommand() {
+        let help = ISOInspectorCLIRunner.helpText()
+        XCTAssertTrue(help.contains("inspect"))
+    }
+
     func testRunExecutesMP4RARefreshWithParsedArguments() throws {
         var capturedSource: URL?
         var capturedOutput: URL?
@@ -23,6 +28,9 @@ final class ISOInspectorCLIScaffoldTests: XCTestCase {
                 capturedSource = source
                 capturedOutput = output
             },
+            makeReader: { _ in StubReader() },
+            parsePipeline: ParsePipeline(buildStream: { _ in AsyncThrowingStream { $0.finish() } }),
+            formatter: EventConsoleFormatter(),
             print: { _ in },
             printError: { _ in }
         )
@@ -42,5 +50,91 @@ final class ISOInspectorCLIScaffoldTests: XCTestCase {
 
         XCTAssertEqual(capturedSource, URL(string: "https://example.com/custom.json"))
         XCTAssertEqual(capturedOutput?.path, "/tmp/catalog.json")
+    }
+
+    func testRunInspectPrintsFormattedEvents() throws {
+        let header = try makeHeader(type: "ftyp", size: 24)
+        let descriptor = try XCTUnwrap(BoxCatalog.shared.descriptor(for: header))
+        let issue = ValidationIssue(
+            ruleID: "VR-006",
+            message: "Unknown box encountered",
+            severity: .info
+        )
+        let event = ParseEvent(
+            kind: .willStartBox(header: header, depth: 0),
+            offset: 0,
+            metadata: descriptor,
+            validationIssues: [issue]
+        )
+        var printed: [String] = []
+        let environment = ISOInspectorCLIEnvironment(
+            refreshCatalog: { _, _ in },
+            makeReader: { _ in StubReader() },
+            parsePipeline: ParsePipeline(buildStream: { _ in
+                AsyncThrowingStream { continuation in
+                    continuation.yield(event)
+                    continuation.finish()
+                }
+            }),
+            formatter: EventConsoleFormatter(),
+            print: { printed.append($0) },
+            printError: { _ in }
+        )
+
+        ISOInspectorCLIRunner.run(
+            arguments: [
+                "isoinspect",
+                "inspect",
+                "/tmp/sample.mp4"
+            ],
+            environment: environment
+        )
+
+        let output = try XCTUnwrap(printed.first)
+        XCTAssertTrue(output.contains(descriptor.name))
+        XCTAssertTrue(output.contains(descriptor.summary))
+        XCTAssertTrue(output.contains(issue.message))
+    }
+
+    func testRunInspectRequiresFilePath() {
+        var errors: [String] = []
+        let environment = ISOInspectorCLIEnvironment(
+            refreshCatalog: { _, _ in },
+            makeReader: { _ in StubReader() },
+            parsePipeline: ParsePipeline(buildStream: { _ in AsyncThrowingStream { $0.finish() } }),
+            formatter: EventConsoleFormatter(),
+            print: { _ in },
+            printError: { errors.append($0) }
+        )
+
+        ISOInspectorCLIRunner.run(
+            arguments: [
+                "isoinspect",
+                "inspect"
+            ],
+            environment: environment
+        )
+
+        XCTAssertEqual(errors.last, "inspect requires a file path.")
+    }
+
+    private struct StubReader: RandomAccessReader {
+        let length: Int64 = 0
+
+        func read(at offset: Int64, count: Int) throws -> Data { Data() }
+    }
+
+    private func makeHeader(type: String, size: Int64) throws -> BoxHeader {
+        let fourCC = try FourCharCode(type)
+        let range = Int64(0)..<size
+        let payloadRange = Int64(8)..<size
+        return BoxHeader(
+            type: fourCC,
+            totalSize: size,
+            headerSize: 8,
+            payloadRange: payloadRange,
+            range: range,
+            uuid: nil
+        )
     }
 }


### PR DESCRIPTION
## Summary
- avoid mutating shared state from the inspect command's streaming task by reporting failures inside the task itself

## Testing
- swift test
- python3 scripts/fix_markdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e53fc3515883219ca2a764ef0a9eb7