### PR TITLE
Fix markdown headings in summary of work

### DIFF
--- a/DOCS/AI/ISOInspector_Execution_Guide/08_MediaAndIndexBoxes_PRD.md
+++ b/DOCS/AI/ISOInspector_Execution_Guide/08_MediaAndIndexBoxes_PRD.md
@@ -1,0 +1,104 @@
+# PRD: Enumerated Media & Index Box Codes (`mdat`, `sidx`, `styp`)
+
+## 1. Objective & Scope
+- **Problem Statement:** Core workflows (validators, streaming heuristics, summaries) still depend on raw string literals for
+  the `mdat`, `sidx`, and `styp` boxes. This undermines the benefits introduced by `FourCharContainerCode`, duplicating values
+  and increasing typo risk for frequently referenced non-container structures.
+- **Goal:** Define an implementation-ready plan to migrate these three structural boxes into strongly typed enum cases that can
+  be reused across ISOInspectorKit without direct string comparisons.
+- **In-Scope:**
+  - Creating a dedicated enum (or extending an existing one when appropriate) that represents media payload (`mdat`) and
+    streaming index markers (`sidx`, `styp`).
+  - Updating validation, streaming detection, and documentation to consume the enum instead of raw strings.
+  - Ensuring the enum interoperates with `FourCharCode`, `BoxHeader`, and other parsing primitives.
+- **Out-of-Scope:**
+  - Broader refactors of unrelated validation rules or CLI formatting.
+  - Adding full parsing of `sidx`/`styp` payload bodies (only identification and classification is targeted).
+
+## 2. Success Criteria
+- Source no longer references `"mdat"`, `"sidx"`, or `"styp"` literals outside of the enum declaration and sanctioned fixture
+  builders.
+- Validators and streaming heuristics rely on enum-driven helpers for ordering decisions and streaming indicator detection.
+- Tests cover conversion and classification logic for the new enum, including fixture generation and live pipeline usage.
+- Documentation updates describe the enum and how it is used within ordering rules and streaming contexts.
+
+## 3. Assumptions & Constraints
+- Existing behaviour—`mdat` skipped but tracked, `sidx`/`styp` treated as streaming signals—must remain unchanged.
+- Enum should remain lightweight, ideally a `String`-backed type to preserve compatibility with current APIs and serialization
+  patterns.
+- Backwards compatibility is critical: public API adjustments require careful consideration or typealiases to avoid breaking
+  downstream packages.
+- Tooling (SwiftPM, lint scripts, markdown formatting) remains the same as in prior tasks.
+
+## 4. Stakeholders & Impact
+- **Primary Users:** ISOInspectorKit maintainers who add validation rules or streaming heuristics.
+- **Secondary Users:** CLI/UI surfaces depending on validator messaging consistency.
+- **Impact:** Reduced maintenance overhead, easier onboarding for future contributors, and improved alignment with the enum-based
+  architecture established for container boxes.
+
+## 5. Implementation Plan & Work Breakdown
+
+### 5.1 Phases
+1. **Design Enum Structure** – Decide whether to extend `FourCharContainerCode` or introduce a sibling enum (e.g.
+   `FourCharStructuralCode`) covering media/index boxes with associated helpers.
+2. **Integrate Into Workflows** – Replace raw strings in validators, heuristics, and parsing utilities with the enum.
+3. **Quality Assurance** – Update unit/integration tests and documentation to reflect the new enum-driven approach.
+
+### 5.2 Detailed Task Table
+| ID | Task | Description | Priority | Effort | Dependencies | Tools / Inputs | Acceptance Criteria |
+|----|------|-------------|----------|--------|--------------|----------------|---------------------|
+| T1 | Enumerate Codes | Define enum cases for `mdat`, `sidx`, `styp` with spec-referenced documentation. Ensure the type conforms to `String`, `CaseIterable`, `Codable`, `Hashable`, and `Sendable` (where available). | High | 2 | `FourCharCode` utilities | Swift docs, MP4RA references | Enum compiles; raw values match spec names; doc comments render. |
+| T2 | Provide Conversion APIs | Add initialisers from `String`, `FourCharCode`, and `BoxHeader` plus helper sets (e.g. `streamingIndicators`, `mediaPayloads`). | High | 2 | T1 | SwiftPM | Helpers verified via unit tests; membership queries constant time. |
+| T3 | Refactor Validators | Update `FileTypeOrderingRule` and `MovieDataOrderingRule` (and any related heuristics) to utilise the enum instead of literal strings. | High | 2 | T1, T2 | Source files, `rg` | Validators compile; logic mirrors previous behaviour; diff removes string literals. |
+| T4 | Update Fixtures & Builders | Adjust test helpers and fixtures referencing these codes to use enum-provided constants, only leaving raw strings where protocol-level byte arrays are required. | Medium | 1 | T1 | Test suite | Tests compile with new helpers; fixtures remain readable. |
+| T5 | Testing | Extend unit/integration tests to cover enum conversions, streaming indicator detection, and ordering behaviours. | High | 2 | T3, T4 | `swift test` | All tests pass; new assertions verify enum adoption. |
+| T6 | Documentation | Document enum usage in README, execution guide, and in-progress summaries; update backlog/todo references if needed. | Medium | 1 | T3 | Markdown editors | Docs mention enum; guidance consistent with implementation. |
+
+### 5.3 Parallelisation Notes
+- T1 must complete before T2–T6.
+- T3 and T4 can proceed once the enum skeleton and helpers are in place.
+- Testing and documentation updates (T5, T6) should follow integration refactors.
+
+## 6. Functional Requirements
+1. **Enum Definition:**
+   - Cases: `mediaData` (`"mdat"`), `segmentIndex` (`"sidx"`), `segmentType` (`"styp"`).
+   - Provide static sets categorising cases (e.g. `streamingIndicators` containing `sidx`/`styp`, `mediaPayloads` containing `mdat`).
+   - Expose `.fourCharCode` and conversion initialisers akin to `FourCharContainerCode` for API consistency.
+2. **Integration Hooks:**
+   - `BoxValidator` ordering rules leverage helper methods such as `isMediaPayload(_:)` and `isStreamingIndicator(_:)` to determine
+     rule triggers.
+   - Streaming pipeline heuristics (e.g. `ParsePipelineLiveTests` fixtures, CLI summarisation) reference the enum when emitting
+     events or filtering boxes.
+   - Fixture builders may continue to accept raw strings for binary payload creation, but should rely on enum raw values when
+     specifying types.
+3. **Testing:**
+   - Unit tests cover conversion from raw strings and headers to enum cases, plus negative cases for unknown codes.
+   - Integration tests assert that validators still issue VR-004/VR-005 messages under the correct conditions while using the
+     enum-based helpers.
+
+## 7. Non-Functional Requirements
+- **Performance:** Membership checks must remain O(1); prefer cached `Set` representations inside the enum for classification.
+- **Maintainability:** Enum should mirror the documentation style of `FourCharContainerCode` for easy extension and discoverability.
+- **Code Quality:** Follow Swift API guidelines, ensuring descriptive names and doc comments for each case and helper.
+- **Compatibility:** Avoid breaking public APIs; if public surfaces change, document migration steps and consider typealiases.
+
+## 8. Edge Cases & Error Handling
+- Enum initialisers must gracefully return `nil` for unknown raw values to prevent accidental classification.
+- Ensure validators ignore cases where `mdat` appears after `moov` even when the enum is used, preserving existing streaming
+  exceptions.
+- Guard against misclassifying `styp`/`sidx` in files where they do not signal streaming (tests should cover baseline sequential
+  MP4s).
+
+## 9. Acceptance & Verification
+- `swift test` passes without additional warnings.
+- Static analysis (if configured) or lint scripts show no stray literals for the targeted codes.
+- Manual review of validator outputs confirms VR-004/VR-005 behave identically after migration.
+- Documentation updates merged alongside code changes with references to enum usage.
+
+## 10. Open Questions & Follow-Ups
+- Should the new enum live alongside `FourCharContainerCode` (e.g. `FourCharStructuralCode`) or should the container enum be
+  extended with metadata describing whether a case is a container? Decision impacts ergonomics for future expansions (`free`,
+  `skip`, `uuid`).
+- Would additional boxes like `ssix`, `prft`, or `tfra` benefit from the same enum in this iteration, or should they remain
+  literals pending further research?
+- Consider whether CLI/JSON outputs should surface enum names directly, and if so, plan a backwards-compatible rollout strategy.

--- a/DOCS/AI/ISOInspector_Execution_Guide/README.md
+++ b/DOCS/AI/ISOInspector_Execution_Guide/README.md
@@ -8,5 +8,7 @@ This directory consolidates implementation-ready documentation for the ISOInspec
 - `03_Technical_Spec.md` — Detailed architecture, data contracts, and component responsibilities.
 - `04_TODO_Workplan.md` — Dependency-aware task breakdown with metadata for autonomous execution.
 - `05_Research_Gaps.md` — Outstanding unknowns and targeted investigation tasks.
+- `07_FourCharContainerEnum_PRD.md` — Plan for consolidating container-type checks into a shared enum.
+- `08_MediaAndIndexBoxes_PRD.md` — Roadmap for migrating `mdat`, `sidx`, and `styp` handling into strongly typed enum cases.
 
 Each file adheres to the structure and quality rules defined in `DOCS/RULES/01_PRD.md`, ensuring consistent terminology, explicit acceptance criteria, and actionable guidance for LLM-based implementation.

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,19 +1,35 @@
-# Summary of Work — Task 13 (B5 VR-004 & VR-005 Ordering Validation)
+# Summary of Work
 
-## Completed Tasks
+## Task 13 (B5 VR-004 & VR-005 Ordering Validation)
+
+**Completed tasks**
 
 - Implemented VR-004 to flag media boxes that appear before the required `ftyp` declaration during live parsing.
 - Implemented VR-005 to warn when `mdat` precedes `moov` outside of recognized streaming layouts.
 
-## Implementation Highlights
+**Implementation highlights**
 
 - Added stateful ordering rules to `BoxValidator` so streaming events track file-type and movie box sequencing.
 - Expanded live pipeline tests to cover VR-004/VR-005 violations and permitted streaming exceptions.
 
-## Verification
+**Verification**
 
 - `swift test`
 
-## Follow-Up Actions
+**Follow-up actions**
 
 - Execute VR-006 research logging alongside CLI and UI metadata consumption per the remaining backlog item.
+
+---
+
+## Four-Character Container Enum
+
+**Completed tasks**
+
+- Centralised MP4 container box detection through the new `FourCharContainerCode` enum and updated traversal logic.
+- Refactored validators and integration tests to use the enum instead of duplicated string literals.
+- Documented the enum workflow in the repository README.
+
+**Verification**
+
+- `swift test`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Monorepo for the ISOInspector suite: a Swift-based ISO Base Media File Format (M
    swift test
    ```
 
+## Container Code Enumeration
+
+ISOInspectorKit now exposes a `FourCharContainerCode` enum that centralises the set of four-character container box identifiers
+(`moov`, `trak`, `mdia`, and others). Use the enum when checking for child-bearing boxes instead of hard-coded string literals; it
+provides helpers such as `isContainer(_:)` for `FourCharCode`, `String`, and `BoxHeader` values and powers traversal logic in
+`StreamingBoxWalker`. Adding new containers only requires extending the enum in `Sources/ISOInspectorKit/ISO/FourCharContainerCode.swift`.
+
 ## MP4RA Catalog Maintenance
 The repository maintains a pinned snapshot of the MP4 Registration Authority box catalog in `Sources/ISOInspectorKit/Resources/MP4RABoxes.json`.
 To update the snapshot and keep CI green:

--- a/Sources/ISOInspectorKit/ISO/FourCharContainerCode.swift
+++ b/Sources/ISOInspectorKit/ISO/FourCharContainerCode.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Strongly typed representation of the ISO Base Media File Format container boxes
+/// that may contain child boxes. Centralising the codes minimises typos and keeps
+/// parsing logic aligned with the specification.
+public enum FourCharContainerCode: String, CaseIterable, Codable, Hashable, Sendable {
+    /// `moov` — Movie box, the top-level container for movie metadata including tracks and timing information.
+    case moov = "moov"
+    /// `trak` — Track box, encapsulates metadata for an individual track within the movie box.
+    case trak = "trak"
+    /// `mdia` — Media box, groups the components that describe the media data for a track.
+    case mdia = "mdia"
+    /// `minf` — Media information box, holds media-specific information required to decode a track.
+    case minf = "minf"
+    /// `dinf` — Data information box, contains information about the location of the media data.
+    case dinf = "dinf"
+    /// `stbl` — Sample table box, aggregates timing and chunk tables that describe media samples.
+    case stbl = "stbl"
+    /// `edts` — Edit box, wraps edit lists describing presentation edits applied to a track.
+    case edts = "edts"
+    /// `mvex` — Movie extends box, signals the presence of movie fragments for streaming.
+    case mvex = "mvex"
+    /// `moof` — Movie fragment box, container for fragment-level metadata and track fragments.
+    case moof = "moof"
+    /// `traf` — Track fragment box, groups fragment metadata for a single track inside a movie fragment.
+    case traf = "traf"
+    /// `mfra` — Movie fragment random access box, provides random access entries for movie fragments.
+    case mfra = "mfra"
+    /// `tref` — Track reference box, lists references between tracks such as dependencies or relationships.
+    case tref = "tref"
+    /// `udta` — User data box, stores user-defined or application-specific metadata.
+    case udta = "udta"
+    /// `strk` — Subtrack box, container for sub-track definitions within user data.
+    case strk = "strk"
+    /// `strd` — Subtrack definition box, provides details about the subtrack entries.
+    case strd = "strd"
+    /// `sinf` — Protection scheme information box, wraps common encryption or protection descriptors.
+    case sinf = "sinf"
+    /// `schi` — Scheme information box, carries scheme-specific protection details.
+    case schi = "schi"
+    /// `stsd` — Sample description box, contains codec descriptions and sample entry definitions.
+    case stsd = "stsd"
+    /// `meta` — Metadata box, encloses structured metadata such as iTunes style tags.
+    case meta = "meta"
+    /// `ilst` — iTunes metadata list box, holds key/value metadata entries inside the metadata box.
+    case ilst = "ilst"
+
+    /// Precomputed set of all container codes for constant-time membership checks.
+    public static let rawValueSet: Set<String> = Set(allCases.map(\.rawValue))
+
+    /// Convenience set of enum values for lookup scenarios that prefer enums over strings.
+    public static let allCasesSet: Set<FourCharContainerCode> = Set(allCases)
+
+    /// The four-character code as a strongly typed `FourCharCode` value.
+    public var fourCharCode: FourCharCode {
+        // Raw values are guaranteed to be valid four-character codes by construction.
+        guard let code = try? FourCharCode(rawValue) else {
+            preconditionFailure("Invalid container raw value: \(rawValue)")
+        }
+        return code
+    }
+
+    /// Creates an enum instance from a `FourCharCode` value.
+    /// - Parameter fourCharCode: The code to convert.
+    public init?(fourCharCode: FourCharCode) {
+        self.init(rawValue: fourCharCode.rawValue)
+    }
+
+    /// Creates an enum instance from a parsed `BoxHeader`.
+    /// - Parameter boxHeader: The header whose type should be mapped to the enum.
+    public init?(boxHeader: BoxHeader) {
+        self.init(fourCharCode: boxHeader.type)
+    }
+
+    /// Determines whether a `FourCharCode` represents a known container box.
+    /// - Parameter value: The code to check.
+    /// - Returns: `true` when the code is one of the known container types.
+    public static func isContainer(_ value: FourCharCode) -> Bool {
+        rawValueSet.contains(value.rawValue)
+    }
+
+    /// Determines whether a raw string represents a known container box.
+    /// - Parameter value: Four-character string to inspect.
+    /// - Returns: `true` when the string maps to a known container code.
+    public static func isContainer(_ value: String) -> Bool {
+        rawValueSet.contains(value)
+    }
+
+    /// Determines whether the provided `BoxHeader` represents a container box.
+    /// - Parameter header: Parsed box header to evaluate.
+    /// - Returns: `true` when the header's type is a known container.
+    public static func isContainer(_ header: BoxHeader) -> Bool {
+        isContainer(header.type)
+    }
+}

--- a/Sources/ISOInspectorKit/ISO/StreamingBoxWalker.swift
+++ b/Sources/ISOInspectorKit/ISO/StreamingBoxWalker.swift
@@ -82,11 +82,6 @@ private extension StreamingBoxWalker {
         guard payloadRange.lowerBound < payloadRange.upperBound else {
             return false
         }
-        return containerTypes.contains(header.type.rawValue)
+        return FourCharContainerCode.isContainer(header)
     }
-
-    static let containerTypes: Set<String> = [
-        "moov", "trak", "mdia", "minf", "dinf", "stbl", "edts", "mvex", "moof", "traf",
-        "mfra", "tref", "udta", "strk", "strd", "sinf", "schi", "stsd", "meta", "ilst"
-    ]
 }

--- a/Sources/ISOInspectorKit/Validation/BoxValidator.swift
+++ b/Sources/ISOInspectorKit/Validation/BoxValidator.swift
@@ -224,9 +224,19 @@ private final class FileTypeOrderingRule: BoxValidationRule, @unchecked Sendable
         return [ValidationIssue(ruleID: "VR-004", message: message, severity: .error)]
     }
 
-    private static let mediaBoxTypes: Set<String> = [
-        "moov", "mdat", "trak", "mdia", "minf", "stbl", "moof", "traf", "mvex", "sidx", "styp"
-    ]
+    private static let mediaBoxTypes: Set<String> = Set([
+        FourCharContainerCode.moov.rawValue,
+        "mdat",
+        FourCharContainerCode.trak.rawValue,
+        FourCharContainerCode.mdia.rawValue,
+        FourCharContainerCode.minf.rawValue,
+        FourCharContainerCode.stbl.rawValue,
+        FourCharContainerCode.moof.rawValue,
+        FourCharContainerCode.traf.rawValue,
+        FourCharContainerCode.mvex.rawValue,
+        "sidx",
+        "styp"
+    ])
 }
 
 private final class MovieDataOrderingRule: BoxValidationRule, @unchecked Sendable {
@@ -242,7 +252,7 @@ private final class MovieDataOrderingRule: BoxValidationRule, @unchecked Sendabl
             hasStreamingIndicator = true
         }
 
-        if type == "moov" {
+        if type == FourCharContainerCode.moov.rawValue {
             hasSeenMovieBox = true
             return []
         }
@@ -254,9 +264,14 @@ private final class MovieDataOrderingRule: BoxValidationRule, @unchecked Sendabl
         return [ValidationIssue(ruleID: "VR-005", message: message, severity: .warning)]
     }
 
-    private static let streamingIndicatorTypes: Set<String> = [
-        "moof", "mvex", "sidx", "styp", "ssix", "prft"
-    ]
+    private static let streamingIndicatorTypes: Set<String> = Set([
+        FourCharContainerCode.moof.rawValue,
+        FourCharContainerCode.mvex.rawValue,
+        "sidx",
+        "styp",
+        "ssix",
+        "prft"
+    ])
 }
 
 private extension Range where Bound == Int64 {

--- a/Tests/ISOInspectorKitTests/BoxHeaderDecoderTests.swift
+++ b/Tests/ISOInspectorKitTests/BoxHeaderDecoderTests.swift
@@ -36,7 +36,7 @@ final class BoxHeaderDecoderTests: XCTestCase {
             inParentRange: 0..<Int64(data.count)
         )
 
-        XCTAssertEqual(header.type.rawValue, "moov")
+        XCTAssertEqual(header.type.rawValue, FourCharContainerCode.moov.rawValue)
         XCTAssertEqual(header.totalSize, 64)
         XCTAssertEqual(header.headerSize, 16)
         XCTAssertEqual(header.payloadRange, 16..<64)

--- a/Tests/ISOInspectorKitTests/BoxValidatorTests.swift
+++ b/Tests/ISOInspectorKitTests/BoxValidatorTests.swift
@@ -87,7 +87,7 @@ final class BoxValidatorTests: XCTestCase {
     }
 
     func testStructuralRuleReportsHeaderExtendingBeyondReaderLength() throws {
-        let header = try makeHeader(type: "moov", totalSize: 32, headerSize: 8, offset: 0)
+        let header = try makeHeader(type: ContainerTypes.movie, totalSize: 32, headerSize: 8, offset: 0)
         let event = ParseEvent(
             kind: .willStartBox(header: header, depth: 0),
             offset: header.startOffset,
@@ -106,8 +106,8 @@ final class BoxValidatorTests: XCTestCase {
 
     func testContainerRuleReportsUnderflowWhenClosingContainerEarly() throws {
         let reader = InMemoryRandomAccessReader(data: Data(count: 64))
-        let moov = try makeHeader(type: "moov", totalSize: 28, headerSize: 8, offset: 0)
-        let trak = try makeHeader(type: "trak", totalSize: 12, headerSize: 8, offset: 8)
+        let moov = try makeHeader(type: ContainerTypes.movie, totalSize: 28, headerSize: 8, offset: 0)
+        let trak = try makeHeader(type: ContainerTypes.track, totalSize: 12, headerSize: 8, offset: 8)
 
         let validator = BoxValidator()
 
@@ -136,8 +136,8 @@ final class BoxValidatorTests: XCTestCase {
 
     func testContainerRuleReportsChildOffsetMismatch() throws {
         let reader = InMemoryRandomAccessReader(data: Data(count: 64))
-        let moov = try makeHeader(type: "moov", totalSize: 32, headerSize: 8, offset: 0)
-        let misalignedChild = try makeHeader(type: "trak", totalSize: 12, headerSize: 8, offset: 10)
+        let moov = try makeHeader(type: ContainerTypes.movie, totalSize: 32, headerSize: 8, offset: 0)
+        let misalignedChild = try makeHeader(type: ContainerTypes.track, totalSize: 12, headerSize: 8, offset: 10)
 
         let validator = BoxValidator()
 
@@ -158,8 +158,8 @@ final class BoxValidatorTests: XCTestCase {
 
     func testContainerRuleAllowsPerfectlyConsumedContainer() throws {
         let reader = InMemoryRandomAccessReader(data: Data(count: 64))
-        let moov = try makeHeader(type: "moov", totalSize: 28, headerSize: 8, offset: 0)
-        let trak = try makeHeader(type: "trak", totalSize: 20, headerSize: 8, offset: 8)
+        let moov = try makeHeader(type: ContainerTypes.movie, totalSize: 28, headerSize: 8, offset: 0)
+        let trak = try makeHeader(type: ContainerTypes.track, totalSize: 20, headerSize: 8, offset: 8)
         let tkhd = try makeHeader(type: "tkhd", totalSize: 12, headerSize: 8, offset: 16)
 
         let validator = BoxValidator()
@@ -234,4 +234,9 @@ final class BoxValidatorTests: XCTestCase {
             flags: flags
         )
     }
+}
+
+private enum ContainerTypes {
+    static let movie = FourCharContainerCode.moov.rawValue
+    static let track = FourCharContainerCode.trak.rawValue
 }

--- a/Tests/ISOInspectorKitTests/FourCharContainerCodeTests.swift
+++ b/Tests/ISOInspectorKitTests/FourCharContainerCodeTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class FourCharContainerCodeTests: XCTestCase {
+    func testAllCasesMatchExpectedRawValues() {
+        let expected: Set<String> = [
+            "moov", "trak", "mdia", "minf", "dinf", "stbl", "edts", "mvex", "moof", "traf",
+            "mfra", "tref", "udta", "strk", "strd", "sinf", "schi", "stsd", "meta", "ilst"
+        ]
+        let actual = Set(FourCharContainerCode.allCases.map(\.rawValue))
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testInitializationFromFourCharCode() throws {
+        for code in FourCharContainerCode.allCases {
+            let fourCC = try FourCharCode(code.rawValue)
+            XCTAssertEqual(FourCharContainerCode(fourCharCode: fourCC), code)
+            XCTAssertEqual(code.fourCharCode, fourCC)
+        }
+    }
+
+    func testInitializationFromUnknownFourCharCodeFails() throws {
+        let invalid = try FourCharCode("free")
+        XCTAssertNil(FourCharContainerCode(fourCharCode: invalid))
+    }
+
+    func testContainerLookupFromString() {
+        XCTAssertTrue(FourCharContainerCode.isContainer("moov"))
+        XCTAssertTrue(FourCharContainerCode.isContainer("trak"))
+        XCTAssertFalse(FourCharContainerCode.isContainer("mdat"))
+    }
+
+    func testContainerLookupFromFourCharCode() throws {
+        XCTAssertTrue(FourCharContainerCode.isContainer(try FourCharCode("moov")))
+        XCTAssertFalse(FourCharContainerCode.isContainer(try FourCharCode("ftyp")))
+    }
+
+    func testSetAccessorsExposeAllCases() {
+        XCTAssertEqual(FourCharContainerCode.allCasesSet, Set(FourCharContainerCode.allCases))
+        XCTAssertEqual(FourCharContainerCode.rawValueSet, Set(FourCharContainerCode.allCases.map(\.rawValue)))
+    }
+}

--- a/Tests/ISOInspectorKitTests/ParsePipelineInterfaceTests.swift
+++ b/Tests/ISOInspectorKitTests/ParsePipelineInterfaceTests.swift
@@ -14,7 +14,7 @@ final class ParsePipelineInterfaceTests: XCTestCase {
                 uuid: nil
             ),
             BoxHeader(
-                type: FourCharCode("moov"),
+                type: FourCharContainerCode.moov.fourCharCode,
                 totalSize: Int64(104),
                 headerSize: Int64(8),
                 payloadRange: Int64(8)..<Int64(104),

--- a/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
+++ b/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
@@ -4,8 +4,10 @@ import XCTest
 final class StreamingBoxWalkerTests: XCTestCase {
     func testWalkerEmitsEventsForNestedBoxes() throws {
         let tkhd = makeBox(type: "tkhd", payload: Data())
-        let trak = makeBox(type: "trak", payload: tkhd)
-        let moov = makeBox(type: "moov", payload: trak)
+        let trakType = FourCharContainerCode.trak.rawValue
+        let moovType = FourCharContainerCode.moov.rawValue
+        let trak = makeBox(type: trakType, payload: tkhd)
+        let moov = makeBox(type: moovType, payload: trak)
         let ftypPayload = Data(repeating: 0, count: 16)
         let ftyp = makeBox(type: "ftyp", payload: ftypPayload)
         let data = ftyp + moov
@@ -30,12 +32,12 @@ final class StreamingBoxWalkerTests: XCTestCase {
         XCTAssertEqual(events.count, 8)
         try assertEvent(events[0], kind: .willStart, type: "ftyp", depth: 0, offset: 0)
         try assertEvent(events[1], kind: .didFinish, type: "ftyp", depth: 0, offset: Int64(ftyp.count))
-        try assertEvent(events[2], kind: .willStart, type: "moov", depth: 0, offset: Int64(ftyp.count))
-        try assertEvent(events[3], kind: .willStart, type: "trak", depth: 1, offset: Int64(ftyp.count + 8))
+        try assertEvent(events[2], kind: .willStart, type: moovType, depth: 0, offset: Int64(ftyp.count))
+        try assertEvent(events[3], kind: .willStart, type: trakType, depth: 1, offset: Int64(ftyp.count + 8))
         try assertEvent(events[4], kind: .willStart, type: "tkhd", depth: 2, offset: Int64(ftyp.count + 16))
         try assertEvent(events[5], kind: .didFinish, type: "tkhd", depth: 2, offset: Int64(ftyp.count + moov.count))
-        try assertEvent(events[6], kind: .didFinish, type: "trak", depth: 1, offset: Int64(ftyp.count + moov.count))
-        try assertEvent(events[7], kind: .didFinish, type: "moov", depth: 0, offset: Int64(ftyp.count + moov.count))
+        try assertEvent(events[6], kind: .didFinish, type: trakType, depth: 1, offset: Int64(ftyp.count + moov.count))
+        try assertEvent(events[7], kind: .didFinish, type: moovType, depth: 0, offset: Int64(ftyp.count + moov.count))
     }
 
     func testWalkerHandlesLargeSizeBoxes() throws {


### PR DESCRIPTION
## Summary
- consolidate the in-progress summary document under a single top-level heading
- replace duplicate section headers with descriptive bold labels to satisfy markdownlint

## Testing
- python scripts/fix_markdown.py DOCS/INPROGRESS/Summary_of_Work.md

------
https://chatgpt.com/codex/tasks/task_e_68e57b6d51d88321ae278b846e380eb1