### PR TITLE
Introduce MediaAndIndexBoxCode enum for media and index boxes

### DIFF
--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -33,3 +33,17 @@
 **Verification**
 
 - `swift test`
+
+---
+
+## Media & Index Box Enumeration
+
+**Completed tasks**
+
+- Added `MediaAndIndexBoxCode` to strongly type `mdat`, `sidx`, and `styp` along with conversion helpers and category sets.
+- Refactored ordering and streaming validators to rely on enum-driven checks instead of raw strings.
+- Updated integration/unit tests and README guidance to describe the new enum-centric workflow.
+
+**Verification**
+
+- `swift test`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ ISOInspectorKit now exposes a `FourCharContainerCode` enum that centralises the 
 provides helpers such as `isContainer(_:)` for `FourCharCode`, `String`, and `BoxHeader` values and powers traversal logic in
 `StreamingBoxWalker`. Adding new containers only requires extending the enum in `Sources/ISOInspectorKit/ISO/FourCharContainerCode.swift`.
 
+## Media & Index Box Enumeration
+
+Companion enum `MediaAndIndexBoxCode` tracks frequently referenced structural boxes such as `mdat`, `sidx`, and `styp`. The type
+offers the same conversion helpers as the container enum, plus convenience sets for streaming indicators and media payloads.
+Ordering rules and streaming heuristics rely on these helpers to avoid scattered string literals; extend
+`Sources/ISOInspectorKit/ISO/MediaAndIndexBoxCode.swift` when additional structural boxes gain first-class support.
+
 ## MP4RA Catalog Maintenance
 The repository maintains a pinned snapshot of the MP4 Registration Authority box catalog in `Sources/ISOInspectorKit/Resources/MP4RABoxes.json`.
 To update the snapshot and keep CI green:

--- a/Sources/ISOInspectorKit/ISO/MediaAndIndexBoxCode.swift
+++ b/Sources/ISOInspectorKit/ISO/MediaAndIndexBoxCode.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Enumerates frequently used non-container structural boxes that influence ordering
+/// and streaming heuristics in ISO Base Media File Format files.
+public enum MediaAndIndexBoxCode: String, CaseIterable, Codable, Hashable, Sendable {
+    /// `mdat` — Media data box containing raw encoded media payloads.
+    case mediaData = "mdat"
+    /// `sidx` — Segment index box signalling streaming segment boundaries.
+    case segmentIndex = "sidx"
+    /// `styp` — Segment type box describing segment compatibility for streaming.
+    case segmentType = "styp"
+
+    /// Convenience set of all known raw values for constant-time lookups.
+    public static let rawValueSet: Set<String> = Set(allCases.map(\.rawValue))
+
+    /// Convenience set of enum values for callers that prefer typed membership checks.
+    public static let allCasesSet: Set<MediaAndIndexBoxCode> = Set(allCases)
+
+    /// Set of enum values that represent streaming indicators.
+    public static let streamingIndicators: Set<MediaAndIndexBoxCode> = [.segmentIndex, .segmentType]
+
+    /// Set of enum values that represent media payload containers.
+    public static let mediaPayloads: Set<MediaAndIndexBoxCode> = [.mediaData]
+
+    /// Lazily cached set of raw strings for streaming indicator checks.
+    private static let streamingIndicatorRawValues: Set<String> = Set(streamingIndicators.map(\.rawValue))
+
+    /// Lazily cached set of raw strings for media payload checks.
+    private static let mediaPayloadRawValues: Set<String> = Set(mediaPayloads.map(\.rawValue))
+
+    /// The four-character code representation.
+    public var fourCharCode: FourCharCode {
+        guard let code = try? FourCharCode(rawValue) else {
+            preconditionFailure("Invalid media/index raw value: \(rawValue)")
+        }
+        return code
+    }
+
+    /// Attempts to create the enum from a strongly typed `FourCharCode`.
+    /// - Parameter fourCharCode: The code to convert.
+    public init?(fourCharCode: FourCharCode) {
+        self.init(rawValue: fourCharCode.rawValue)
+    }
+
+    /// Attempts to create the enum from a parsed box header.
+    /// - Parameter boxHeader: Header whose type should be mapped to the enum.
+    public init?(boxHeader: BoxHeader) {
+        self.init(fourCharCode: boxHeader.type)
+    }
+
+    /// Determines whether the provided value represents a known media payload box.
+    /// - Parameter value: The enum case to evaluate.
+    public static func isMediaPayload(_ value: MediaAndIndexBoxCode) -> Bool {
+        mediaPayloads.contains(value)
+    }
+
+    /// Determines whether the provided four-character code maps to a known media payload box.
+    /// - Parameter value: The four-character code to evaluate.
+    public static func isMediaPayload(_ value: FourCharCode) -> Bool {
+        mediaPayloadRawValues.contains(value.rawValue)
+    }
+
+    /// Determines whether the provided raw string maps to a known media payload box.
+    /// - Parameter value: The four-character string to evaluate.
+    public static func isMediaPayload(_ value: String) -> Bool {
+        mediaPayloadRawValues.contains(value)
+    }
+
+    /// Determines whether the provided header type maps to a known media payload box.
+    /// - Parameter header: The box header to evaluate.
+    public static func isMediaPayload(_ header: BoxHeader) -> Bool {
+        isMediaPayload(header.type)
+    }
+
+    /// Determines whether the provided value represents a known streaming indicator box.
+    /// - Parameter value: The enum case to evaluate.
+    public static func isStreamingIndicator(_ value: MediaAndIndexBoxCode) -> Bool {
+        streamingIndicators.contains(value)
+    }
+
+    /// Determines whether the provided four-character code maps to a known streaming indicator box.
+    /// - Parameter value: The four-character code to evaluate.
+    public static func isStreamingIndicator(_ value: FourCharCode) -> Bool {
+        streamingIndicatorRawValues.contains(value.rawValue)
+    }
+
+    /// Determines whether the provided raw string maps to a known streaming indicator box.
+    /// - Parameter value: The four-character string to evaluate.
+    public static func isStreamingIndicator(_ value: String) -> Bool {
+        streamingIndicatorRawValues.contains(value)
+    }
+
+    /// Determines whether the provided header represents a known streaming indicator box.
+    /// - Parameter header: The box header to evaluate.
+    public static func isStreamingIndicator(_ header: BoxHeader) -> Bool {
+        isStreamingIndicator(header.type)
+    }
+}

--- a/Sources/ISOInspectorKit/Validation/BoxValidator.swift
+++ b/Sources/ISOInspectorKit/Validation/BoxValidator.swift
@@ -224,19 +224,20 @@ private final class FileTypeOrderingRule: BoxValidationRule, @unchecked Sendable
         return [ValidationIssue(ruleID: "VR-004", message: message, severity: .error)]
     }
 
-    private static let mediaBoxTypes: Set<String> = Set([
-        FourCharContainerCode.moov.rawValue,
-        "mdat",
-        FourCharContainerCode.trak.rawValue,
-        FourCharContainerCode.mdia.rawValue,
-        FourCharContainerCode.minf.rawValue,
-        FourCharContainerCode.stbl.rawValue,
-        FourCharContainerCode.moof.rawValue,
-        FourCharContainerCode.traf.rawValue,
-        FourCharContainerCode.mvex.rawValue,
-        "sidx",
-        "styp"
-    ])
+    private static let mediaBoxTypes: Set<String> = {
+        var values: Set<String> = [
+            FourCharContainerCode.moov.rawValue,
+            FourCharContainerCode.trak.rawValue,
+            FourCharContainerCode.mdia.rawValue,
+            FourCharContainerCode.minf.rawValue,
+            FourCharContainerCode.stbl.rawValue,
+            FourCharContainerCode.moof.rawValue,
+            FourCharContainerCode.traf.rawValue,
+            FourCharContainerCode.mvex.rawValue
+        ]
+        values.formUnion(MediaAndIndexBoxCode.rawValueSet)
+        return values
+    }()
 }
 
 private final class MovieDataOrderingRule: BoxValidationRule, @unchecked Sendable {
@@ -257,21 +258,23 @@ private final class MovieDataOrderingRule: BoxValidationRule, @unchecked Sendabl
             return []
         }
 
-        guard type == "mdat" else { return [] }
+        guard MediaAndIndexBoxCode.isMediaPayload(type) else { return [] }
         guard !hasSeenMovieBox, !hasStreamingIndicator else { return [] }
 
         let message = "Movie data box (mdat) encountered before movie box (moov); ensure initialization metadata precedes media."
         return [ValidationIssue(ruleID: "VR-005", message: message, severity: .warning)]
     }
 
-    private static let streamingIndicatorTypes: Set<String> = Set([
-        FourCharContainerCode.moof.rawValue,
-        FourCharContainerCode.mvex.rawValue,
-        "sidx",
-        "styp",
-        "ssix",
-        "prft"
-    ])
+    private static let streamingIndicatorTypes: Set<String> = {
+        var values: Set<String> = [
+            FourCharContainerCode.moof.rawValue,
+            FourCharContainerCode.mvex.rawValue,
+            "ssix",
+            "prft"
+        ]
+        values.formUnion(MediaAndIndexBoxCode.streamingIndicators.map(\.rawValue))
+        return values
+    }()
 }
 
 private extension Range where Bound == Int64 {

--- a/Tests/ISOInspectorKitTests/FourCharContainerCodeTests.swift
+++ b/Tests/ISOInspectorKitTests/FourCharContainerCodeTests.swift
@@ -27,7 +27,7 @@ final class FourCharContainerCodeTests: XCTestCase {
     func testContainerLookupFromString() {
         XCTAssertTrue(FourCharContainerCode.isContainer("moov"))
         XCTAssertTrue(FourCharContainerCode.isContainer("trak"))
-        XCTAssertFalse(FourCharContainerCode.isContainer("mdat"))
+        XCTAssertFalse(FourCharContainerCode.isContainer(MediaAndIndexBoxCode.mediaData.rawValue))
     }
 
     func testContainerLookupFromFourCharCode() throws {

--- a/Tests/ISOInspectorKitTests/MediaAndIndexBoxCodeTests.swift
+++ b/Tests/ISOInspectorKitTests/MediaAndIndexBoxCodeTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class MediaAndIndexBoxCodeTests: XCTestCase {
+    func testAllCasesMatchRawValues() {
+        let expectedRawValues: Set<String> = [
+            MediaAndIndexBoxCode.mediaData.rawValue,
+            MediaAndIndexBoxCode.segmentIndex.rawValue,
+            MediaAndIndexBoxCode.segmentType.rawValue
+        ]
+
+        XCTAssertEqual(MediaAndIndexBoxCode.rawValueSet, expectedRawValues)
+        XCTAssertEqual(
+            Set(MediaAndIndexBoxCode.allCases),
+            Set(expectedRawValues.compactMap(MediaAndIndexBoxCode.init(rawValue:)))
+        )
+    }
+
+    func testConversionFromFourCharCode() throws {
+        let media = MediaAndIndexBoxCode.mediaData.fourCharCode
+        let segmentIndex = MediaAndIndexBoxCode.segmentIndex.fourCharCode
+        let segmentType = MediaAndIndexBoxCode.segmentType.fourCharCode
+
+        XCTAssertEqual(MediaAndIndexBoxCode(fourCharCode: media), .mediaData)
+        XCTAssertEqual(MediaAndIndexBoxCode(fourCharCode: segmentIndex), .segmentIndex)
+        XCTAssertEqual(MediaAndIndexBoxCode(fourCharCode: segmentType), .segmentType)
+    }
+
+    func testConversionFromBoxHeader() throws {
+        let mediaHeader = try makeHeader(type: MediaAndIndexBoxCode.mediaData.rawValue)
+        let segmentIndexHeader = try makeHeader(type: MediaAndIndexBoxCode.segmentIndex.rawValue)
+        let segmentTypeHeader = try makeHeader(type: MediaAndIndexBoxCode.segmentType.rawValue)
+
+        XCTAssertEqual(MediaAndIndexBoxCode(boxHeader: mediaHeader), .mediaData)
+        XCTAssertEqual(MediaAndIndexBoxCode(boxHeader: segmentIndexHeader), .segmentIndex)
+        XCTAssertEqual(MediaAndIndexBoxCode(boxHeader: segmentTypeHeader), .segmentType)
+    }
+
+    func testUnknownValuesReturnNil() throws {
+        let invalidCode = try FourCharCode("free")
+        let header = try makeHeader(type: "free")
+
+        XCTAssertNil(MediaAndIndexBoxCode(fourCharCode: invalidCode))
+        XCTAssertNil(MediaAndIndexBoxCode(boxHeader: header))
+        XCTAssertFalse(MediaAndIndexBoxCode.isMediaPayload(invalidCode))
+        XCTAssertFalse(MediaAndIndexBoxCode.isStreamingIndicator(header))
+    }
+
+    func testMediaPayloadClassification() throws {
+        let mediaHeader = try makeHeader(type: MediaAndIndexBoxCode.mediaData.rawValue)
+        let mediaCode = MediaAndIndexBoxCode.mediaData.fourCharCode
+
+        XCTAssertTrue(MediaAndIndexBoxCode.isMediaPayload(mediaHeader))
+        XCTAssertTrue(MediaAndIndexBoxCode.isMediaPayload(mediaCode))
+        XCTAssertTrue(MediaAndIndexBoxCode.isMediaPayload(MediaAndIndexBoxCode.mediaData.rawValue))
+
+        XCTAssertFalse(MediaAndIndexBoxCode.isMediaPayload(MediaAndIndexBoxCode.segmentIndex.rawValue))
+        XCTAssertFalse(MediaAndIndexBoxCode.isMediaPayload(MediaAndIndexBoxCode.segmentType.rawValue))
+    }
+
+    func testStreamingIndicatorClassification() throws {
+        let segmentIndexHeader = try makeHeader(type: MediaAndIndexBoxCode.segmentIndex.rawValue)
+        let segmentTypeHeader = try makeHeader(type: MediaAndIndexBoxCode.segmentType.rawValue)
+        let segmentIndexCode = MediaAndIndexBoxCode.segmentIndex.fourCharCode
+
+        XCTAssertTrue(MediaAndIndexBoxCode.isStreamingIndicator(segmentIndexHeader))
+        XCTAssertTrue(MediaAndIndexBoxCode.isStreamingIndicator(segmentTypeHeader))
+        XCTAssertTrue(MediaAndIndexBoxCode.isStreamingIndicator(segmentIndexCode))
+        XCTAssertTrue(MediaAndIndexBoxCode.isStreamingIndicator(MediaAndIndexBoxCode.segmentType.rawValue))
+
+        XCTAssertFalse(MediaAndIndexBoxCode.isStreamingIndicator(MediaAndIndexBoxCode.mediaData.rawValue))
+        XCTAssertFalse(
+            MediaAndIndexBoxCode.isStreamingIndicator(
+                try makeHeader(type: MediaAndIndexBoxCode.mediaData.rawValue)
+            )
+        )
+    }
+
+    private func makeHeader(type: String) throws -> BoxHeader {
+        BoxHeader(
+            type: try FourCharCode(type),
+            totalSize: 16,
+            headerSize: 8,
+            payloadRange: 8..<16,
+            range: 0..<16,
+            uuid: nil
+        )
+    }
+}

--- a/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
+++ b/Tests/ISOInspectorKitTests/StreamingBoxWalkerTests.swift
@@ -42,7 +42,8 @@ final class StreamingBoxWalkerTests: XCTestCase {
 
     func testWalkerHandlesLargeSizeBoxes() throws {
         let payload = Data(repeating: 0xFF, count: 12)
-        let largeBox = makeBox(type: "mdat", payload: payload, useLargeSize: true)
+        let mediaType = MediaAndIndexBoxCode.mediaData.rawValue
+        let largeBox = makeBox(type: mediaType, payload: payload, useLargeSize: true)
         let reader = InMemoryRandomAccessReader(data: largeBox)
         let walker = StreamingBoxWalker()
 
@@ -61,8 +62,8 @@ final class StreamingBoxWalkerTests: XCTestCase {
 
         XCTAssertTrue(finished)
         XCTAssertEqual(events.count, 2)
-        try assertEvent(events[0], kind: .willStart, type: "mdat", depth: 0, offset: 0)
-        try assertEvent(events[1], kind: .didFinish, type: "mdat", depth: 0, offset: Int64(largeBox.count))
+        try assertEvent(events[0], kind: .willStart, type: mediaType, depth: 0, offset: 0)
+        try assertEvent(events[1], kind: .didFinish, type: mediaType, depth: 0, offset: Int64(largeBox.count))
     }
 
     func testWalkerPropagatesHeaderErrors() {


### PR DESCRIPTION
## Summary
- add a MediaAndIndexBoxCode enum with conversion helpers and category sets for mdat, sidx, and styp
- refactor ordering validators and integration tests to rely on the new enum instead of raw string literals
- document the enum usage and record the work in the in-progress summary

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e584cda6b88321802c1b890b76ba7b