### PR TITLE
Add research log persistence for VR-006

### DIFF
--- a/DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md
+++ b/DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md
@@ -16,7 +16,7 @@ The following plan decomposes delivery into dependency-aware phases. Each task i
 | B2 | Build box header decoder supporting 32-bit, 64-bit, and `uuid` boxes. | High | 2 | B1 | Swift, XCTest | Unit tests for standard and extended headers; handles malformed sizes gracefully. (Completed ✅) |
 | B3 | Implement streaming parse pipeline with event emission and context stack. | High | 3 | B2 | Swift Concurrency, XCTest | Parsing sample files emits ordered events with correct offsets. (Completed ✅) |
 | B4 | Integrate MP4RA metadata catalog and fallback for unknown boxes. | High | 2 | B3 | Swift, JSON parsing | Catalog loads from bundled JSON; unknown types logged for research. |
-| B5 | Implement validation rules VR-001 to VR-006 with test coverage. | High | 2 | B3 | XCTest | Malformed fixtures trigger expected validation outcomes. |
+| B5 | Implement validation rules VR-001 to VR-006 with test coverage. | High | 2 | B3 | XCTest | Malformed fixtures trigger expected validation outcomes. (Completed ✅ — VR-006 research logging now persists unknown boxes to a shared research log for CLI/UI analysis.) |
 | B6 | Add JSON and binary export modules with regression tests. | Medium | 1.5 | B3 | Swift Codable | Exported files re-import successfully; CLI smoke tests pass. |
 
 ## Phase C — User Interface Package

--- a/DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md
+++ b/DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md
@@ -121,6 +121,9 @@ Create a **Swift** library (`ISOInspectorKit`) and a **multiplatform SwiftUI app
 
 ## 5) Detailed TODO (execution-ready, без кода)
 
+> Update (2025-10-07): VR-006 research logging now persists unknown boxes to a shared JSON research log exposed through the CLI `--research-log` option and UI consumers.
+
+
 ### Phase A — IO Foundations
 - [ ] A1. Define `RandomAccessReader` protocol: `length`, `read(at:count:)`, endian helpers (`readU32BE`, `readU64BE`, `readFourCC`).
 - [ ] A2. Implement `MappedReader` using `Data(contentsOf:options:.mappedIfSafe)`; provide bounds-checked slices.

--- a/DOCS/INPROGRESS/14_B5_VR006_Research_Logging.md
+++ b/DOCS/INPROGRESS/14_B5_VR006_Research_Logging.md
@@ -8,29 +8,44 @@ parses are persisted for follow-up analysis across CLI and UI workflows.
 ## 🧩 Context
 
 - Execution workplan task **B5** calls for finishing validation rules VR-001 through VR-006 once the streaming pipeline
+
   is available, and VR-006 is the remaining research-focused follow-up.
+
 - Recent archive notes highlight the need to pair VR-006 logging with CLI/UI metadata consumers so ordering and catalog
+
   insights propagate downstream.
+
 - The technical specification defines VR-006 as recording unknown box types in a research log and treating the findings
+
   as info-level issues.
 
 ## ✅ Success Criteria
 
 - Unknown or catalog-missing boxes encountered by the parser append deduplicated entries (fourcc, path, offsets) to a
+
   persistent research log file accessible to subsequent CLI/UI runs.
+
 - CLI surface: `validate`/`inspect` commands expose flags or default behavior to enable VR-006 logging and confirm log file location, with tests proving log entries are emitted.
 - UI surface: metadata consumers receive VR-006 research entries alongside validation issues so warnings and info events
+
   remain visible in tree/detail panes.
+
 - Documentation in TODO/PRD trackers updated to reflect VR-006 logging availability and guidance for analysts.
 
 ## 🔧 Implementation Notes
 
 - Reuse or extend existing diagnostics logging infrastructure to capture VR-006 events without blocking streaming
+
   throughput; ensure async-safe writes.
+
 - Coordinate storage location and format (e.g., JSONL or CSV) so CLI and UI share the same research log schema and
+
   dedupe strategy.
+
 - Validate behavior with fixtures that include unknown fourcc entries and catalog mismatches to guarantee VR-006 issues
+
   propagate through CLI/UI pipelines.
+
 - Review prior VR-004/VR-005 ordering work to ensure logging preserves ordering context for downstream analysis.
 
 ## 🧠 Source References

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,21 @@
+# Summary of Work — VR-006 Research Logging
+
+## Completed Tasks
+
+- Implemented persistent VR-006 research logging with deduplicated JSON storage shared by CLI and UI consumers.
+- Added configurable research log handling to the CLI with `--research-log` option and default location announcement.
+- Updated documentation trackers and TODOs to note VR-006 logging availability for analysts.
+
+## Key Changes
+
+- Added `ResearchLogEntry`/`ResearchLogWriter` infrastructure and extended `ParsePipeline` to record unknown boxes using contextual metadata.
+- Enhanced CLI environment to provision research log writers, parse the `--research-log` flag, and surface the log path before streaming events.
+- Expanded test coverage for research logging across kit and CLI layers.
+
+## Validation
+
+- `swift test`
+
+## Follow-ups
+
+- Monitor research log schema usage once UI components evolve beyond the current scaffold.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,3 +1,3 @@
 # Next Tasks
 
-- [ ] Execute VR-006 research logging alongside the CLI and UI metadata consumption work tracked in `todo.md #3`, ensuring ordering insights flow into downstream consumers.
+- [x] Execute VR-006 research logging alongside the CLI and UI metadata consumption work tracked in `todo.md #3`, ensuring ordering insights flow into downstream consumers.

--- a/Sources/ISOInspectorKit/Validation/ResearchLogWriter.swift
+++ b/Sources/ISOInspectorKit/Validation/ResearchLogWriter.swift
@@ -1,0 +1,105 @@
+import Dispatch
+import Foundation
+
+public struct ResearchLogEntry: Codable, Hashable, Sendable {
+    public let boxType: String
+    public let filePath: String
+    public let startOffset: Int64
+    public let endOffset: Int64
+
+    public init(boxType: String, filePath: String, startOffset: Int64, endOffset: Int64) {
+        self.boxType = boxType
+        self.filePath = filePath
+        self.startOffset = startOffset
+        self.endOffset = endOffset
+    }
+}
+
+public protocol ResearchLogRecording: Sendable {
+    func record(_ entry: ResearchLogEntry)
+}
+
+public final class ResearchLogWriter: ResearchLogRecording, @unchecked Sendable {
+    private let fileURL: URL
+    private let queue = DispatchQueue(label: "ISOInspectorKit.ResearchLogWriter")
+    private var entries: Set<ResearchLogEntry>
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+    private let logger = DiagnosticsLogger(subsystem: "ISOInspectorKit", category: "ResearchLog")
+
+    public init(fileURL: URL) throws {
+        self.fileURL = fileURL
+        self.encoder = JSONEncoder()
+        self.encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        self.decoder = JSONDecoder()
+        self.entries = try Self.loadExistingEntries(from: fileURL, decoder: decoder)
+    }
+
+    public func record(_ entry: ResearchLogEntry) {
+        queue.sync {
+            guard entries.insert(entry).inserted else {
+                return
+            }
+            do {
+                try persistLocked()
+            } catch {
+                logger.error("Failed to persist research log entry: \(error)")
+            }
+        }
+    }
+
+    public func loadEntries() -> [ResearchLogEntry] {
+        queue.sync { sortedEntriesLocked() }
+    }
+
+    public static func defaultLogURL(fileManager: FileManager = .default) -> URL {
+        let base = fileManager.homeDirectoryForCurrentUser
+            .appendingPathComponent(".isoinspector", isDirectory: true)
+        return base.appendingPathComponent("research-log.json", isDirectory: false)
+    }
+
+    private func persistLocked() throws {
+        try ensureDirectoryExists()
+        let data = try encoder.encode(sortedEntriesLocked())
+        try data.write(to: fileURL, options: .atomic)
+    }
+
+    private func ensureDirectoryExists() throws {
+        let directory = fileURL.deletingLastPathComponent()
+        guard !directory.path.isEmpty else { return }
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: directory.path, isDirectory: &isDirectory) {
+            if isDirectory.boolValue {
+                return
+            }
+            throw CocoaError(.fileWriteFileExists)
+        }
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    private static func loadExistingEntries(from url: URL, decoder: JSONDecoder) throws -> Set<ResearchLogEntry> {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return []
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            guard !data.isEmpty else { return [] }
+            let decoded = try decoder.decode([ResearchLogEntry].self, from: data)
+            return Set(decoded)
+        } catch {
+            throw error
+        }
+    }
+
+    private func sortedEntriesLocked() -> [ResearchLogEntry] {
+        entries.sorted(by: { lhs, rhs in
+            if lhs.boxType == rhs.boxType {
+                if lhs.filePath == rhs.filePath {
+                    return lhs.startOffset < rhs.startOffset
+                }
+                return lhs.filePath < rhs.filePath
+            }
+            return lhs.boxType < rhs.boxType
+        })
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -7,3 +7,4 @@
     - [x] VR-002 Container boxes must close exactly at their declared payload size.
     - [x] VR-004 `ftyp` must appear before any media box.
     - [x] VR-005 `moov` must precede `mdat` unless flagged streaming.
+    - [x] VR-006 Research log persists unknown boxes for follow-up analysis.


### PR DESCRIPTION
## Summary
- add ResearchLogEntry/Writer infrastructure and extend the parse pipeline to record VR-006 research entries with context
- update the CLI to surface research log configuration, including a --research-log option and default location message
- expand kit/CLI test coverage and update documentation trackers to reflect the new VR-006 logging workflow

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_e_68e58d1ac2dc8321b0f49abaef75eb5f