### PR TITLE
Fix VR-006 doc lint spacing and add markdown title rule

### DIFF
--- a/DOCS/INPROGRESS/15_Monitor_VR006_Research_Log_Adoption.md
+++ b/DOCS/INPROGRESS/15_Monitor_VR006_Research_Log_Adoption.md
@@ -1,0 +1,41 @@
+# Monitor VR-006 Research Log Adoption
+
+## 🎯 Objective
+
+Establish monitoring and integration checkpoints so VR-006 research log entries remain available and consistent across
+CLI and upcoming UI components.
+
+## 🧩 Context
+
+- Execution workplan task **B5** delivered persistent VR-006 logging shared between CLI and UI consumers, and downstream
+  teams flagged the need to keep observing how the schema is consumed as interfaces
+  mature.【F:DOCS/AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md†L13-L22】
+- Root backlog item `todo.md #3` now tracks the remaining validation follow-ups and explicitly calls out VR-006 logging as complete, making cross-surface adoption the next logical focus.【F:todo.md†L1-L10】
+- CLI help text already advertises VR-006 research log streaming via the `inspect` command, so documentation and telemetry must stay accurate while UI bindings come online.【F:Sources/ISOInspectorCLI/CLI.swift†L1-L86】
+
+## ✅ Success Criteria
+
+- Schema usage audit confirms CLI output, persisted research log files, and any UI viewer prototypes all read identical
+  fields and severity semantics.
+- Monitoring checklist created for upcoming UI milestones covering VR-006 event binding, log locations, and analyst
+  workflows.
+- Documentation updates proposed (or merged) to flag any schema adjustments required by UI components.
+- No regression in existing VR-006 tests or CLI behaviors after any follow-up changes.
+
+## 🔧 Implementation Notes
+
+- Pair with UI task owners in Phase C/E to capture when components begin consuming `ParseEvent.validationIssues` for VR-006 info-level records.
+- Expand automated smoke tests (or add TODOs) once UI integrations exist, ensuring research log writers and viewers
+  remain aligned.
+- Keep coordination with MP4RA catalog refresh pipeline so unknown box metadata stays correlated between validation
+  warnings and research entries.
+- Revisit archived VR-006 research logging summary for historical decisions when drafting monitoring
+  artifacts.【F:DOCS/TASK_ARCHIVE/14_B5_VR006_Research_Logging/Summary_of_Work.md†L1-L7】
+
+## 🧠 Source References
+
+- [`ISOInspector_Master_PRD.md`](../AI/ISOViewer/ISOInspector_PRD_Full/ISOInspector_Master_PRD.md)
+- [`04_TODO_Workplan.md`](../AI/ISOInspector_Execution_Guide/04_TODO_Workplan.md)
+- [`ISOInspector_PRD_TODO.md`](../AI/ISOViewer/ISOInspector_PRD_TODO.md)
+- [`DOCS/RULES`](../RULES)
+- Archived context in [`DOCS/TASK_ARCHIVE`](../TASK_ARCHIVE)

--- a/DOCS/RULES/06_Markdown_Title_Rules.md
+++ b/DOCS/RULES/06_Markdown_Title_Rules.md
@@ -1,0 +1,20 @@
+# 06 — Markdown Title Rules
+
+## ✅ Required Rules
+
+1. **Don’t use `"` characters in headings or titles.** They cause markdownlint to fail during CI. Keep headings plain text or use other punctuation when emphasis is needed.
+   - Example CI failure message:
+
+     ```text
+     Error: DOCS/INPROGRESS/15_Monitor_VR006_Research_Log_Adoption.md:3 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Below] [Context: "## 🎯 Objective"] https://github.com/DavidAnson/markdownlint/blob/v0.31.1/doc/md022.md
+     ```
+
+## 📌 Scope
+
+These rules apply to every Markdown file in the repository, especially content under `DOCS/**` that participates in automated linting.
+
+## 🛠 Recommended Practice
+
+- Prefer descriptive wording or emojis instead of quotes when highlighting phrases.
+- Run `python scripts/fix_markdown.py` before committing to normalize spacing around headings and lists.
+- Validate with `markdownlint-cli2` locally if you introduce new heading patterns.


### PR DESCRIPTION
## Summary
- normalize spacing in the VR-006 research log monitoring doc so headings and lists respect markdownlint expectations
- add a markdown title rules guide capturing the new restriction against using quotes in headings

## Testing
- python scripts/fix_markdown.py

------
https://chatgpt.com/codex/tasks/task_e_68e5fbf3200483218e0a17e116b9ed59