### PR TITLE
Add VR-006 research log SwiftUI previews

### DIFF
--- a/DOCS/INPROGRESS/04_Integrate_ResearchLogMonitor_SwiftUI_Previews.md
+++ b/DOCS/INPROGRESS/04_Integrate_ResearchLogMonitor_SwiftUI_Previews.md
@@ -6,14 +6,20 @@ Create SwiftUI preview scaffolding that runs `ResearchLogMonitor.audit(logURL:)`
 
 ## 🧩 Context
 
-- Backlog item `todo.md #4` and the active next-task list call for wiring the audit helper into SwiftUI previews to keep VR-006 research log bindings in sync as the UI comes online.【F:todo.md†L11-L12】【F:DOCS/INPROGRESS/next_tasks.md†L1-L5】
-- The VR-006 monitoring checklist flags SwiftUI preview integration as the remaining pre-UI milestone now that the audit
-  helper and CLI schema banner ship
-  together.【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L5-L28】
-- `ResearchLogMonitor.swift` already exposes the schema metadata and audit logic, including TODO markers for this integration, so previews must exercise it without diverging from the shared schema definition.【F:Sources/ISOInspectorKit/Validation/ResearchLogMonitor.swift†L3-L85】
+- Backlog item `todo.md #4` tracks the SwiftUI preview integration work.
+  - Source: 【F:todo.md†L11-L12】
+- The active next-task list calls for wiring the audit helper into SwiftUI previews so VR-006 bindings stay aligned.
+  - Source: 【F:DOCS/INPROGRESS/next_tasks.md†L1-L5】
+- VR-006 monitoring checklist keeps SwiftUI preview integration as the remaining pre-UI milestone.
+  - Source: 【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L5-L28】
+- The audit helper and CLI schema banner already ship together, so previews must match the shared schema metadata.
+  - Source: 【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L5-L28】
+- `ResearchLogMonitor.swift` exposes the schema metadata and audit logic, including TODO markers for this integration, so previews must exercise it without diverging from the shared schema definition.
+  - Source: 【F:Sources/ISOInspectorKit/Validation/ResearchLogMonitor.swift†L3-L85】
 - Upcoming SwiftUI surfaces will bind parse output and validation issues per the product backlog, requiring consistent
-  research log metadata when analysts review unknown
-  boxes.【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L110-L140】【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/15_Monitor_VR006_Research_Log_Adoption.md†L1-L58】
+  research log metadata when analysts review unknown boxes.
+  - Sources:
+    【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L110-L140】【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/15_Monitor_VR006_Research_Log_Adoption.md†L1-L58】
 
 ## ✅ Success Criteria
 
@@ -28,14 +34,16 @@ Create SwiftUI preview scaffolding that runs `ResearchLogMonitor.audit(logURL:)`
 ## 🔧 Implementation Notes
 
 - Reuse existing CLI fixtures or craft a minimal JSON sample under app resources to exercise the audit helper, matching
-  the VR-006 schema fields and
-  version.【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L30-L38】【F:Sources/ISOInspectorKit/Validation/ResearchLogMonitor.swift†L3-L85】
+  the VR-006 schema fields and version.
+  - Sources:
+    【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L30-L38】【F:Sources/ISOInspectorKit/Validation/ResearchLogMonitor.swift†L3-L85】
 - Provide preview-only adapters (e.g., `PreviewResearchLogProvider`) that locate or synthesize the log file, allowing multiple UI previews to share the same audit result while remaining deterministic.
 - Capture guidance in code comments or developer docs referencing the monitoring checklist so future work on telemetry
-  (next-task follow-up) knows where to hook in once UI smoke tests
-  exist.【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L22-L28】
+  (next-task follow-up) knows where to hook in once UI smoke tests exist.
+  - Source: 【F:DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md†L22-L28】
 - Coordinate with upcoming UI state stores and parse pipelines described in the PRD to ensure the preview scaffolding
-  aligns with planned view models and validation issue bindings.【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L110-L140】
+  aligns with planned view models and validation issue bindings.
+  - Source: 【F:DOCS/AI/ISOViewer/ISOInspector_PRD_TODO.md†L110-L140】
 
 ## 🧠 Source References
 

--- a/DOCS/INPROGRESS/Summary_of_Work.md
+++ b/DOCS/INPROGRESS/Summary_of_Work.md
@@ -1,0 +1,19 @@
+# Summary of Work — October 8, 2025
+
+## Completed Tasks
+
+- Integrated `ResearchLogMonitor.audit(logURL:)` into SwiftUI previews through the new preview provider and diagnostics view scaffolding.
+
+## Implementation Highlights
+
+- Added `ResearchLogPreviewProvider` and deterministic VR-006 fixtures so previews reuse the same schema metadata that powers the CLI audit helper.
+- Created `ResearchLogPreviewProviderTests` to guard success, missing fixture, and schema mismatch scenarios and keep the preview pipeline wired into `ResearchLogMonitor`.
+- Introduced `ResearchLogAuditPreview` SwiftUI view plus preview scenarios that visualize schema alignment, drift, and missing fixture diagnostics for VR-006.
+
+## Documentation & Tracking Updates
+
+- Marked todo item `#4` and the matching next-task checklist entry as complete.
+
+## Follow-up Actions
+
+- Extend telemetry for VR-006 once UI smoke tests exist, per backlog item `todo.md #5`.

--- a/DOCS/INPROGRESS/next_tasks.md
+++ b/DOCS/INPROGRESS/next_tasks.md
@@ -1,6 +1,6 @@
 # Next Tasks
 
-- [ ] Integrate `ResearchLogMonitor.audit(logURL:)` with forthcoming SwiftUI previews so UI bindings stay aligned with the VR-006 research log schema.
+- [x] Integrate `ResearchLogMonitor.audit(logURL:)` with forthcoming SwiftUI previews so UI bindings stay aligned with the VR-006 research log schema.
 - [ ] Extend telemetry once UI smoke tests exist to monitor for missing VR-006 research log entries across CLI and UI
 
   consumers.

--- a/Sources/ISOInspectorApp/ResearchLogAuditPreview.swift
+++ b/Sources/ISOInspectorApp/ResearchLogAuditPreview.swift
@@ -1,0 +1,154 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import ISOInspectorKit
+
+struct ResearchLogAuditPreview: View {
+    let snapshot: ResearchLogPreviewSnapshot
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            Divider()
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(snapshot.diagnostics, id: \.self) { diagnostic in
+                    Label {
+                        Text(diagnostic)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    } icon: {
+                        Image(systemName: "checkmark.seal")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(borderColor, lineWidth: 1)
+        )
+        .padding()
+    }
+
+    @ViewBuilder
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("VR-006 Research Log Audit")
+                .font(.title2)
+                .fontWeight(.semibold)
+            switch snapshot.state {
+            case let .ready(audit):
+                readyHeader(for: audit)
+            case let .missingFixture(audit):
+                missingHeader(for: audit)
+            case let .schemaMismatch(expected, actual):
+                schemaMismatchHeader(expected: expected, actual: actual)
+            case let .loadFailure(message):
+                loadFailureHeader(message: message)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func readyHeader(for audit: ResearchLogAudit) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Fixture \(snapshot.fixtureName) matches ResearchLogSchema.fieldNames.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 4) {
+                GridRow {
+                    Text("Schema")
+                        .gridColumnAlignment(.leading)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text("v\(audit.schemaVersion)")
+                        .font(.subheadline)
+                }
+                GridRow {
+                    Text("Entries")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text("\(audit.entryCount)")
+                        .font(.subheadline.weight(.medium))
+                }
+                GridRow {
+                    Text("Fields")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                    Text(audit.fieldNames.joined(separator: ", "))
+                        .font(.subheadline)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func missingHeader(for audit: ResearchLogAudit) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Missing preview fixture \(snapshot.fixtureName)")
+                .font(.headline)
+                .foregroundStyle(.orange)
+            Text("The shared VR-006 schema v\(audit.schemaVersion) expects fields: \(audit.fieldNames.joined(separator: ", ")).")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private func schemaMismatchHeader(expected: [String], actual: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Schema mismatch detected")
+                .font(.headline)
+                .foregroundStyle(.red)
+            Text("Expected: \(expected.joined(separator: ", "))")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+            Text("Actual: \(actual.joined(separator: ", "))")
+                .font(.callout)
+                .foregroundStyle(.red)
+        }
+    }
+
+    @ViewBuilder
+    private func loadFailureHeader(message: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Failed to load \(snapshot.fixtureName)")
+                .font(.headline)
+                .foregroundStyle(.red)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var borderColor: Color {
+        switch snapshot.state {
+        case .ready:
+            return .green.opacity(0.45)
+        case .missingFixture:
+            return .orange.opacity(0.55)
+        case .schemaMismatch, .loadFailure:
+            return .red.opacity(0.65)
+        }
+    }
+}
+
+#Preview("VR-006 Fixture Ready") {
+    ResearchLogAuditPreview(snapshot: ResearchLogPreviewProvider.validFixture())
+        .previewLayout(.sizeThatFits)
+}
+
+#Preview("VR-006 Fixture Missing") {
+    ResearchLogAuditPreview(snapshot: ResearchLogPreviewProvider.missingFixture())
+        .previewLayout(.sizeThatFits)
+}
+
+#Preview("VR-006 Schema Drift") {
+    ResearchLogAuditPreview(snapshot: ResearchLogPreviewProvider.schemaMismatchFixture())
+        .previewLayout(.sizeThatFits)
+}
+#endif

--- a/Sources/ISOInspectorKit/Resources/VR006PreviewLog.json
+++ b/Sources/ISOInspectorKit/Resources/VR006PreviewLog.json
@@ -1,0 +1,14 @@
+[
+  {
+    "boxType": "zzzz",
+    "filePath": "/ResearchLogs/unknown_box.mp4",
+    "startOffset": 512,
+    "endOffset": 768
+  },
+  {
+    "boxType": "abcd",
+    "filePath": "/ResearchLogs/another_unknown.mp4",
+    "startOffset": 1024,
+    "endOffset": 1536
+  }
+]

--- a/Sources/ISOInspectorKit/Resources/VR006PreviewLog_Mismatch.json
+++ b/Sources/ISOInspectorKit/Resources/VR006PreviewLog_Mismatch.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "zzzz",
+    "path": "/ResearchLogs/unknown_box.mp4",
+    "offsetStart": 512,
+    "offsetEnd": 768
+  }
+]

--- a/Sources/ISOInspectorKit/Support/ResearchLogPreviewProvider.swift
+++ b/Sources/ISOInspectorKit/Support/ResearchLogPreviewProvider.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+public struct ResearchLogPreviewSnapshot: Equatable {
+    public enum State: Equatable, CustomStringConvertible {
+        case ready(ResearchLogAudit)
+        case missingFixture(ResearchLogAudit)
+        case schemaMismatch(expected: [String], actual: [String])
+        case loadFailure(message: String)
+
+        public var description: String {
+            switch self {
+            case .ready:
+                return "ready"
+            case .missingFixture:
+                return "missingFixture"
+            case .schemaMismatch:
+                return "schemaMismatch"
+            case let .loadFailure(message):
+                return "loadFailure(\(message))"
+            }
+        }
+    }
+
+    public let fixtureName: String
+    public let state: State
+    public let diagnostics: [String]
+}
+
+/// Provides deterministic VR-006 research log snapshots for SwiftUI previews so UI developers
+/// can validate bindings against the shared schema before wiring live parse pipelines.
+/// The helper intentionally mirrors the monitoring checkpoints documented in
+/// `DOCS/TASK_ARCHIVE/15_Monitor_VR006_Research_Log_Adoption/VR006_Monitoring_Checklist.md`
+/// by surfacing schema and fixture drift during preview rendering.
+public enum ResearchLogPreviewProvider {
+    private static func resolveBundle(_ bundle: Bundle?) -> Bundle {
+        bundle ?? .module
+    }
+
+    private static func snapshot(
+        resourceName: String,
+        bundle: Bundle?,
+        fileManager: FileManager
+    ) -> ResearchLogPreviewSnapshot {
+        let resolvedBundle = resolveBundle(bundle)
+        let fixtureName = "\(resourceName).json"
+
+        guard let fixtureURL = resolvedBundle.url(
+            forResource: resourceName,
+            withExtension: "json"
+        ) else {
+            let audit = ResearchLogAudit(
+                schemaVersion: ResearchLogSchema.version,
+                fieldNames: ResearchLogSchema.fieldNames,
+                entryCount: 0,
+                logExists: false
+            )
+
+            return ResearchLogPreviewSnapshot(
+                fixtureName: fixtureName,
+                state: .missingFixture(audit),
+                diagnostics: [
+                    "VR-006 preview fixture \(fixtureName) is missing from \(resolvedBundle.bundleURL.lastPathComponent).",
+                    "Update preview resources alongside ResearchLogSchema.fieldNames (\(ResearchLogSchema.fieldNames.joined(separator: ", "))).",
+                    "Consult the VR-006 monitoring checklist to confirm preview fixtures stay in sync with the shared schema."
+                ]
+            )
+        }
+
+        do {
+            let audit = try ResearchLogMonitor.audit(logURL: fixtureURL, fileManager: fileManager)
+            return ResearchLogPreviewSnapshot(
+                fixtureName: fixtureName,
+                state: .ready(audit),
+                diagnostics: [
+                    "VR-006 schema v\(audit.schemaVersion) confirmed for preview fixture \(fixtureName).",
+                    "Fields: \(audit.fieldNames.joined(separator: ", ")).",
+                    "Entries audited: \(audit.entryCount)."
+                ]
+            )
+        } catch let error as ResearchLogMonitor.Error {
+            switch error {
+            case let .schemaMismatch(expected, actual):
+                return ResearchLogPreviewSnapshot(
+                    fixtureName: fixtureName,
+                    state: .schemaMismatch(expected: expected, actual: actual),
+                    diagnostics: [
+                        "Schema mismatch detected for \(fixtureName).",
+                        "Expected fields: \(expected.joined(separator: ", ")).",
+                        "Actual fields: \(actual.joined(separator: ", ")).",
+                        "Update preview fixtures to align with ResearchLogSchema.fieldNames before wiring UI previews."
+                    ]
+                )
+            }
+        } catch {
+            return ResearchLogPreviewSnapshot(
+                fixtureName: fixtureName,
+                state: .loadFailure(message: error.localizedDescription),
+                diagnostics: [
+                    "Failed to audit preview fixture \(fixtureName): \(error.localizedDescription).",
+                    "Confirm preview fixtures contain valid VR-006 JSON arrays before running SwiftUI previews."
+                ]
+            )
+        }
+    }
+
+    public static func validFixture(
+        bundle: Bundle? = nil,
+        fileManager: FileManager = .default
+    ) -> ResearchLogPreviewSnapshot {
+        snapshot(resourceName: "VR006PreviewLog", bundle: bundle, fileManager: fileManager)
+    }
+
+    public static func missingFixture(
+        bundle: Bundle? = nil,
+        fileManager: FileManager = .default
+    ) -> ResearchLogPreviewSnapshot {
+        snapshot(resourceName: "VR006PreviewLog_Missing", bundle: bundle, fileManager: fileManager)
+    }
+
+    public static func schemaMismatchFixture(
+        bundle: Bundle? = nil,
+        fileManager: FileManager = .default
+    ) -> ResearchLogPreviewSnapshot {
+        snapshot(resourceName: "VR006PreviewLog_Mismatch", bundle: bundle, fileManager: fileManager)
+    }
+}

--- a/Tests/ISOInspectorKitTests/ResearchLogPreviewProviderTests.swift
+++ b/Tests/ISOInspectorKitTests/ResearchLogPreviewProviderTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import ISOInspectorKit
+
+final class ResearchLogPreviewProviderTests: XCTestCase {
+    func testValidPreviewFixtureProducesAudit() throws {
+        let snapshot = ResearchLogPreviewProvider.validFixture()
+
+        switch snapshot.state {
+        case let .ready(audit):
+            XCTAssertEqual(audit.schemaVersion, ResearchLogSchema.version)
+            XCTAssertEqual(audit.fieldNames, ResearchLogSchema.fieldNames)
+            XCTAssertEqual(audit.entryCount, 2)
+            XCTAssertTrue(audit.logExists)
+            XCTAssertTrue(snapshot.diagnostics.contains(where: { $0.contains("VR-006") }))
+        default:
+            XCTFail("Expected ready snapshot, received \(snapshot.state)")
+        }
+    }
+
+    func testMissingPreviewFixtureFlagsMissingLog() {
+        let snapshot = ResearchLogPreviewProvider.missingFixture()
+
+        switch snapshot.state {
+        case let .missingFixture(audit):
+            XCTAssertFalse(audit.logExists)
+            XCTAssertTrue(snapshot.diagnostics.contains(where: { $0.lowercased().contains("missing") }))
+        default:
+            XCTFail("Expected missing fixture snapshot, received \(snapshot.state)")
+        }
+    }
+
+    func testSchemaMismatchFixtureSurfacesFieldDifferences() {
+        let snapshot = ResearchLogPreviewProvider.schemaMismatchFixture()
+
+        switch snapshot.state {
+        case let .schemaMismatch(expected, actual):
+            XCTAssertEqual(expected, ResearchLogSchema.fieldNames.sorted())
+            XCTAssertTrue(actual.contains("type"))
+            XCTAssertTrue(snapshot.diagnostics.contains(where: { $0.lowercased().contains("schema mismatch") }))
+        default:
+            XCTFail("Expected schema mismatch snapshot, received \(snapshot.state)")
+        }
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -8,5 +8,5 @@
     - [x] VR-004 `ftyp` must appear before any media box.
     - [x] VR-005 `moov` must precede `mdat` unless flagged streaming.
     - [x] VR-006 Research log persists unknown boxes for follow-up analysis.
-- [ ] #4 Integrate ResearchLogMonitor with SwiftUI previews once VR-006 UI surfaces consume research entries.
+- [x] #4 Integrate ResearchLogMonitor with SwiftUI previews once VR-006 UI surfaces consume research entries.
 - [ ] #5 Emit telemetry during UI smoke tests to flag missing VR-006 research log events.


### PR DESCRIPTION
## Summary
- add `ResearchLogPreviewProvider` plus VR-006 preview fixtures so SwiftUI previews reuse the shared audit pipeline
- introduce a SwiftUI `ResearchLogAuditPreview` view with ready, missing, and schema mismatch preview scenarios
- cover the preview helper with unit tests and document completion of the VR-006 preview integration task

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68e613e3b37483218d2ff2671f2b5477