### PR TITLE
Fix banner tap routing and session restore crash

### DIFF
--- a/Sources/ISOInspectorApp/AppShellView.swift
+++ b/Sources/ISOInspectorApp/AppShellView.swift
@@ -160,7 +160,11 @@
                     if shouldShowCorruptionRibbon {
                         CorruptionWarningRibbon(
                             metrics: windowController.issueMetrics,
-                            onTap: windowController.focusIntegrityDiagnostics,
+                            onTap: {
+                                if !showInspector { toggleInspectorVisibility() }
+                                windowController.focusIntegrityDiagnostics()
+                                dismissCorruptionRibbon()
+                            },
                             onDismiss: dismissCorruptionRibbon
                         ).padding(.horizontal).transition(
                             .move(edge: .top).combined(with: .opacity))

--- a/Sources/ISOInspectorApp/State/Services/SessionPersistenceService.swift
+++ b/Sources/ISOInspectorApp/State/Services/SessionPersistenceService.swift
@@ -58,14 +58,14 @@
             }
 
             sessionFileIDs = Dictionary(
-                uniqueKeysWithValues: sortedFiles.map { file in
+                sortedFiles.map { file in
                     (canonicalIdentifier(for: file.recent.url), file.id)
-                })
+                }, uniquingKeysWith: { first, _ in first })
 
             sessionBookmarkDiffs = Dictionary(
-                uniqueKeysWithValues: sortedFiles.map { file in
+                sortedFiles.map { file in
                     (canonicalIdentifier(for: file.recent.url), file.bookmarkDiffs)
-                })
+                }, uniquingKeysWith: { first, _ in first })
 
             pendingSessionSnapshot = snapshot
         }


### PR DESCRIPTION
## Summary

- **Banner tap did nothing**: Tapping "View Integrity Report" now opens the integrity inspector panel and dismisses the banner. Previously the `onTap` handler only called `focusIntegrityDiagnostics()` which selected a node internally but never set `showInspector = true`, so nothing was visible to the user.
- **Startup crash on duplicate session URLs**: `SessionPersistenceService.applySessionSnapshot` used `Dictionary(uniqueKeysWithValues:)` which fatally crashes when two session file entries share the same canonical URL. Switched to `Dictionary(_:uniquingKeysWith:)` keeping the entry with the lower `orderIndex`.

## Test plan

- [ ] Open a file with integrity issues — banner appears with "View Integrity Report"
- [ ] Tap "View Integrity Report" — inspector panel opens, banner dismisses
- [ ] Relaunch app with a session snapshot that contains duplicate file URLs — no crash
- [ ] All 382 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)